### PR TITLE
Rons issue fixes

### DIFF
--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -2182,6 +2182,16 @@ build out subclasses</skos:editorialNote>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">disrupts phagosome maturation</rdfs:label>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188"/>
+        <pathgo:IAO_0000115>A factor that inhibits one or more of the typical fusions between vesicles and other compartments that occur in normal host endosomal dynamics.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">endosomal vesicle fusion inhibitor factor</rdfs:label>
+    </owl:Class>
 </rdf:RDF>
 
 

--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -2185,12 +2185,24 @@ build out subclasses</skos:editorialNote>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000242">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts the host cell endomembrane system by disrupting fusion between vesicles and other cellular compartments as part of normal host function.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">disrupts endosomal vesicle fusion</rdfs:label>
+        <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <pathgo:IAO_0000115>A factor that inhibits one or more of the typical fusions between vesicles and other compartments that occur in normal host endosomal dynamics.</pathgo:IAO_0000115>
         <rdfs:label xml:lang="en">endosomal vesicle fusion inhibitor factor</rdfs:label>
+        <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
     </owl:Class>
 </rdf:RDF>
 

--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -2189,7 +2189,7 @@ build out subclasses</skos:editorialNote>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000242">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
-        <pathgo:IAO_0000115>A mechanism that disrupts the host cell endomembrane system by disrupting fusion between vesicles and other cellular compartments as part of normal host function.</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115>A mechanism that disrupts the host cell endomembrane system by disrupting fusion between vesicles and other cellular compartments that occur as part of normal host function.</pathgo:IAO_0000115>
         <rdfs:label xml:lang="en">disrupts endosomal vesicle fusion</rdfs:label>
         <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
     </owl:Class>
@@ -2201,7 +2201,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <pathgo:IAO_0000115>A factor that inhibits one or more of the typical fusions between vesicles and other compartments that occur in normal host endosomal dynamics.</pathgo:IAO_0000115>
-        <rdfs:label xml:lang="en">endosomal vesicle fusion inhibitor factor</rdfs:label>
+        <rdfs:label xml:lang="en">endosomal vesicle fusion inhibition factor</rdfs:label>
         <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
     </owl:Class>
 </rdf:RDF>


### PR DESCRIPTION
Added this to PATHGO:0000236 'disrupts host cell endomembrane system' for now.  If we see more examples of endosomal trafficking disruption not related to vesicle fusion inhibition, we'll need a more general term for that. 