### PR TITLE
More fixes to the Makefile

### DIFF
--- a/pathgo.obo
+++ b/pathgo.obo
@@ -1,348 +1,292 @@
 format-version: 1.2
-data-version: pathgo/releases/2019-02-21/pathgo.owl
+data-version: pathgo/releases/2020-09-03/pathgo.owl
 remark: Pathogenesis gene ontology
+remark: This material is licensed to the public under CC BY-NC 4.0.  The U.S. Government has “Unlimited Rights” as granted and defined under FAR 52.227-14.
+remark: ©2020 The Johns Hopkins University Applied Physics Laboratory LLC (JHU/APL).  All Rights Reserved.\n\nThis material may be only be used, modified, or reproduced by or for the U.S. Government pursuant to the license rights granted under the clauses at DFARS 252.227-7013/7014 or FAR 52.227-14. For any other permission, please contact the Office of Technology Transfer at JHU/APL.\n\nNO WARRANTY, NO LIABILITY. THIS MATERIAL IS PROVIDED “AS IS.” JHU/APL MAKES NO REPRESENTATION OR WARRANTY WITH RESPECT TO THE PERFORMANCE OF THE MATERIALS, INCLUDING THEIR SAFETY, EFFECTIVENESS, OR COMMERCIAL VIABILITY, AND DISCLAIMS ALL WARRANTIES IN THE MATERIAL, WHETHER EXPRESS OR IMPLIED, INCLUDING (BUT NOT LIMITED TO) ANY AND ALL IMPLIED WARRANTIES OF PERFORMANCE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT OF INTELLECTUAL PROPERTY OR OTHER THIRD PARTY RIGHTS. ANY USER OF THE MATERIAL ASSUMES THE ENTIRE RISK AND LIABILITY FOR USING THE MATERIAL. IN NO EVENT SHALL JHU/APL BE LIABLE TO ANY USER OF THE MATERIAL FOR ANY ACTUAL, INDIRECT, CONSEQUENTIAL, SPECIAL OR OTHER DAMAGES ARISING FROM THE USE OF, OR INABILITY TO USE, THE MATERIAL, INCLUDING, BUT NOT LIMITED TO, ANY DAMAGES FOR LOST PROFITS.
 ontology: PATHGO
-owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019>))\nDeclaration(Class(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111>))\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019> (process or component of toxicity)\n\nSubClassOf(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019> owl:Thing)\n\n# Class: <http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111> (process or component of virulence)\n\nSubClassOf(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111> owl:Thing)\n\n\n)
+owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111>))\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111> (process or component of pathogenicity)\n\nSubClassOf(<http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111> owl:Thing)\n\n\n)
 
 [Term]
 id: PATHGO:0000001
 name: determinant of phospholipase activity
 is_a: PATHGO:0000193 ! determinant of phospholipid cleavage
+property_value: editorialNote "evaluate for removal, concept covered by GO" xsd:string
 
 [Term]
 id: PATHGO:0000002
 name: elongation factor 2 inactivator
-is_a: PATHGO:0000034 ! determinant of protein synthesis inhibition
-property_value: editorialNote "examples diphtheria toxin and Pseudomonas exotoxin A" xsd:string
+is_a: PATHGO:0000034 ! protein synthesis inhibition factor
+property_value: editorialNote "examples diphtheria toxin and Pseudomonas exotoxin A\n\nRegulation of enzyme activity concepts are covered by GO." xsd:string
+property_value: IAO:0000115 "A gene product that inhibits protein synthesis by inactivation of elongation factor 2." xsd:string
 
 [Term]
 id: PATHGO:0000003
-name: ion transport modulation
-is_a: PATHGO:0000167 ! disruption of cellular transport
+name: mediates ion channel activity modulation
+is_a: PATHGO:0000167 ! disrupts cellular transport
 property_value: editorialNote "direct action on ion channel (voltage or ligand gated) or ion pump," xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cellular transport by modulating ion channel activity." xsd:string
 
 [Term]
 id: PATHGO:0000004
-name: determinant of toxicity
-is_a: PATHGO:0000019 ! process or component of toxicity
-property_value: IAO:0000115 "New definition for determinant of toxicity, with more detail" xsd:string
+name: disruption of cell cycle factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "Elaborate subclasses and document examples" xsd:string
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by disrupting the cell cycle of a host cell." xsd:string
 
 [Term]
 id: PATHGO:0000005
-name: determinant of non-specific T cell activation
-is_a: PATHGO:0000035 ! immune modulator
+name: non-specific T cell activation factor
+is_a: PATHGO:0000035 ! non-productive immune system activation factor
+property_value: editorialNote "superantigens" xsd:string
 
 [Term]
 id: PATHGO:0000006
-name: protein synthesis inhibition
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: mediates protein synthesis inhibition
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating inhibition of protein synthesis." xsd:string
 
 [Term]
 id: PATHGO:0000007
 name: disruption of neurotransmitter release
-is_a: PATHGO:0000003 ! ion transport modulation
+is_a: PATHGO:0000003 ! mediates ion channel activity modulation
 property_value: editorialNote "example agatoxin, omega conotoxin, dendrotoxin" xsd:string
+property_value: editorialNote "inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved" xsd:string
 
 [Term]
 id: PATHGO:0000008
-name: second messenger molecule modulator
-is_a: PATHGO:0000015 ! cellular signaling regulation factor
-
-[Term]
-id: PATHGO:0000009
-name: siderophore
-xref: BVF:0000006
-is_a: PATHGO:0000067 ! nutrient uptake factor
+name: DNA synthesis inhibition factor
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by inhibiting the synthesis of DNA." xsd:string
 
 [Term]
 id: PATHGO:0000010
-name: non-specific T-cell activation
-is_a: PATHGO:0000016 ! immune modulation
+name: mediates non-specific T-cell activation
+is_a: PATHGO:0000031 ! mediates non-productive immune system activation
 property_value: editorialNote "example SEB (superantigens)" xsd:string
 
 [Term]
 id: PATHGO:0000011
 name: post-synaptic membrane potential modulator
-is_a: PATHGO:0000040 ! ion gradient modulator
+is_a: PATHGO:0000040 ! membrane potential disruption factor
+property_value: editorialNote "evaluate placement; inconsistent as child class to membrane potential disruption factor" xsd:string
 
 [Term]
 id: PATHGO:0000012
 name: determinant of exocytosis blockade
 is_a: PATHGO:0000188 ! cellular transport disruption factor
-
-[Term]
-id: PATHGO:0000013
-name: enterotoxin
-is_a: PATHGO:0000046 ! organ system category
-
-[Term]
-id: PATHGO:0000014
-name: intracellular delivery
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that involves delivery of factors into target cells" xsd:string
+property_value: IAO:0000115 "A gene product that mediates cellular transport disruption by blocking exocytosis." xsd:string
 
 [Term]
 id: PATHGO:0000015
-name: cellular signaling regulation factor
-is_a: PATHGO:0000004 ! determinant of toxicity
+name: cellular signaling disruption factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "refine/build out subclasses" xsd:string
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by disrupting host cellular signaling processes." xsd:string
 
 [Term]
 id: PATHGO:0000016
-name: immune modulation
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: modulates host immune function
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by modulating host immune system components and processes.  Immune responses can be at the cellular level, or the organismal level." xsd:string
 
 [Term]
 id: PATHGO:0000017
-name: cardiotoxin
-is_a: PATHGO:0000046 ! organ system category
+name: acid-sensing ion channel inhibitor
+is_a: PATHGO:0000191 ! ion channel activity modulator
+property_value: editorialNote "\"Acid-sensing ion channel 1a (ASIC1a) is the primary acid sensor in mammalian brain.\"  evaluate information\n\nconcept possibly covered by GO" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts ion transport by inhibiting acid-sensing ion channels. Acid-sensing ion channel 1a (ASIC1a) is the primary acid sensor in mammalian brain." xsd:string
 
 [Term]
 id: PATHGO:0000018
-name: synaptic vesicle release blockade
-is_a: PATHGO:0000047 ! exocytosis blockade
+name: disrupts synaptic vesicle release
+is_a: PATHGO:0000047 ! disrupts exocytosis
 property_value: editorialNote "examples tetanus bot toxin" xsd:string
+property_value: editorialNote "inconsistent as a subclass as this is a specific case of disrupting exocytosis and not a mechanism by which exocytosis is disrupted" xsd:string
+property_value: IAO:0000115 "A mechanism that prevents exocytosis by blocking release of synaptic vesicles." xsd:string
 
 [Term]
 id: PATHGO:0000019
-name: process or component of toxicity
-
-[Term]
-id: PATHGO:0000020
-name: myotoxin
-is_a: PATHGO:0000046 ! organ system category
+name: determinant of type I secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000021
 name: disruption of post-synaptic membrane potential
-is_a: PATHGO:0000003 ! ion transport modulation
+is_a: PATHGO:0000003 ! mediates ion channel activity modulation
 property_value: editorialNote "example alpha bungarotoxin; cardiac glycosides (post syn calcium in muscle)" xsd:string
+property_value: editorialNote "inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved" xsd:string
 
 [Term]
 id: PATHGO:0000022
 name: action potential propagation modulator
-is_a: PATHGO:0000040 ! ion gradient modulator
+is_a: PATHGO:0000040 ! membrane potential disruption factor
+property_value: IAO:0000115 "A gene product that modulates the propagation of action potentials by disrupting membrane potentials." xsd:string
 
 [Term]
 id: PATHGO:0000023
 name: disruption of action potential propagation
-is_a: PATHGO:0000003 ! ion transport modulation
+is_a: PATHGO:0000003 ! mediates ion channel activity modulation
 property_value: editorialNote "example tetrodotoxin, scorpion toxins" xsd:string
+property_value: editorialNote "inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved" xsd:string
 
 [Term]
 id: PATHGO:0000024
 name: synaptic vesicle release blocker
 is_a: PATHGO:0000012 ! determinant of exocytosis blockade
-property_value: editorialNote "example tetanus toxin (synaptobrevin cleavage), bot toxin (snare cleavage)" xsd:string
+property_value: editorialNote "example tetanus toxin (synaptobrevin cleavage; molecular target synaptobrevin), bot toxin (snare cleavage; molecular target snare protein)" xsd:string
+property_value: IAO:0000115 "A gene product that prevents exocytosis by blocking release of synaptic vesicles." xsd:string
 
 [Term]
 id: PATHGO:0000025
-name: elongation factor 2 inactivation
-is_a: PATHGO:0000006 ! protein synthesis inhibition
+name: mediates elongation factor 2 inactivation
+is_a: PATHGO:0000006 ! mediates protein synthesis inhibition
 property_value: editorialNote "examples diphtheria toxin and Pseudomonas exotoxin A" xsd:string
-
-[Term]
-id: PATHGO:0000026
-name: hepatotoxin
-is_a: PATHGO:0000046 ! organ system category
-
-[Term]
-id: PATHGO:0000027
-name: neurotransmitter release modulator
-is_a: PATHGO:0000040 ! ion gradient modulator
+property_value: IAO:0000115 "A mechanism that mediates protein synthesis inhibition by inactivation of elongation factor 2." xsd:string
 
 [Term]
 id: PATHGO:0000028
-name: disruption of actin cytoskeleton
-is_a: PATHGO:0000166 ! disruption of cellular structure
+name: disrupts cytoskeleton maintenance
+is_a: PATHGO:0000166 ! disrupts cellular structure
+property_value: IAO:0000115 "A mechanism that disrupts cellular structure by altering maintenance of cytoskeleton." xsd:string
 
 [Term]
 id: PATHGO:0000029
-name: membrane damage
-is_a: PATHGO:0000166 ! disruption of cellular structure
+name: mediates membrane damage
+is_a: PATHGO:0000166 ! disrupts cellular structure
+property_value: editorialNote "consider vacuolization" xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cellular structure by damaging the cell membrane." xsd:string
 
 [Term]
 id: PATHGO:0000030
-name: ribosome inactivation
-is_a: PATHGO:0000006 ! protein synthesis inhibition
+name: mediates ribosome inactivation
+is_a: PATHGO:0000006 ! mediates protein synthesis inhibition
 property_value: editorialNote "examples ricin" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates protein synthesis inhibition by ribosome inactivation." xsd:string
 
 [Term]
 id: PATHGO:0000031
-name: phospholipid cleavage
-is_a: PATHGO:0000029 ! membrane damage
+name: mediates non-productive immune system activation
+is_a: PATHGO:0000016 ! modulates host immune function
+property_value: editorialNote "evaluate class name and intent; determine how to capture superantigens\n\nEvaluate changing label to \"mediates immune system activation\"" xsd:string
 
 [Term]
 id: PATHGO:0000032
 name: determinant of pore formation
 is_a: PATHGO:0000043 ! determinant of membrane damage
+property_value: IAO:0000115 "A gene product that mediates membrane damage by formation of pores." xsd:string
 
 [Term]
 id: PATHGO:0000033
-name: pore formation
-is_a: PATHGO:0000029 ! membrane damage
+name: mediates pore formation
+is_a: PATHGO:0000029 ! mediates membrane damage
+property_value: IAO:0000115 "A mechanism that mediates membrane damage by formation of pores." xsd:string
 
 [Term]
 id: PATHGO:0000034
-name: determinant of protein synthesis inhibition
-is_a: PATHGO:0000004 ! determinant of toxicity
+name: protein synthesis inhibition factor
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by inhibiting protein synthesis." xsd:string
 
 [Term]
 id: PATHGO:0000035
-name: immune modulator
-is_a: PATHGO:0000004 ! determinant of toxicity
-
-[Term]
-id: PATHGO:0000036
-name: mechanism of toxicity
-is_a: PATHGO:0000019 ! process or component of toxicity
-
-[Term]
-id: PATHGO:0000037
-name: dermatoxin
-is_a: PATHGO:0000046 ! organ system category
+name: non-productive immune system activation factor
+is_a: PATHGO:0000081 ! host immune function modulation factor
+property_value: editorialNote "evaluate class name and intent; determine how to capture superantigens" xsd:string
 
 [Term]
 id: PATHGO:0000038
-name: adherence
-is_a: PATHGO:0000147 ! adherence and colonization
-property_value: IAO:0000115 "Mechanism of attachment to a surface" xsd:string
+name: mediates adhesion
+is_a: PATHGO:0000147 ! mediates adherence and colonization
+property_value: IAO:0000115 "A mechanism that enables adhesion and colonization by mediating attachment to other cells or to surfaces." xsd:string
 
 [Term]
 id: PATHGO:0000039
 name: ribosome inactivator
-is_a: PATHGO:0000034 ! determinant of protein synthesis inhibition
+is_a: PATHGO:0000034 ! protein synthesis inhibition factor
 property_value: editorialNote "example ricin" xsd:string
+property_value: IAO:0000115 "A gene product that inhibits protein synthesis by ribosome inactivation." xsd:string
 
 [Term]
 id: PATHGO:0000040
-name: ion gradient modulator
-is_a: PATHGO:0000188 ! cellular transport disruption factor
-
-[Term]
-id: PATHGO:0000041
-name: toxin category
-is_a: PATHGO:0000019 ! process or component of toxicity
-
-[Term]
-id: PATHGO:0000042
-name: nephrotoxin
-is_a: PATHGO:0000046 ! organ system category
+name: membrane potential disruption factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by disrupting membrane potential." xsd:string
 
 [Term]
 id: PATHGO:0000043
 name: determinant of membrane damage
+synonym: "lysin" RELATED []
 is_a: PATHGO:0000182 ! cellular structure disruption factor
-
-[Term]
-id: PATHGO:0000044
-name: vacuolization
-is_a: PATHGO:0000166 ! disruption of cellular structure
-
-[Term]
-id: PATHGO:0000045
-name: pulmonary toxin
-is_a: PATHGO:0000046 ! organ system category
-
-[Term]
-id: PATHGO:0000046
-name: organ system category
-is_a: PATHGO:0000041 ! toxin category
+property_value: IAO:0000115 "A gene product that disrupts cellular structure by damaging the cell membrane." xsd:string
 
 [Term]
 id: PATHGO:0000047
-name: exocytosis blockade
-is_a: PATHGO:0000167 ! disruption of cellular transport
-
-[Term]
-id: PATHGO:0000048
-name: neurotoxin
-is_a: PATHGO:0000046 ! organ system category
+name: disrupts exocytosis
+is_a: PATHGO:0000167 ! disrupts cellular transport
+property_value: IAO:0000115 "A mechanism that disrupts cellular transport by blocking exocytosis." xsd:string
 
 [Term]
 id: PATHGO:0000049
-name: type V secretion system
-is_a: PATHGO:0000102 ! secretion system factor
-
-[Term]
-id: PATHGO:0000050
-name: actin-based intracellular motility
-is_a: PATHGO:0000123 ! intracellular motility
-property_value: IAO:0000115 "Type of intracellular motility that uses actin filaments" xsd:string
+name: determinant of type V secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000051
 name: integrin binding protein
-is_a: PATHGO:0000077 ! extracellular matrix binding protein
+is_a: PATHGO:0000198 ! cell surface binding factor
+property_value: editorialNote "integrin α2β1 binding protein and integrin αMβ2 binding protein are examples that may be too granular to include" xsd:string
+property_value: IAO:0000115 "A gene product that mediates cell surface binding through integrins." xsd:string
 
 [Term]
 id: PATHGO:0000052
 name: surface polysaccharide biosynthesis
-is_a: PATHGO:0000054 ! virulence factor synthesis
-
-[Term]
-id: PATHGO:0000053
-name: VEGF secretion
-is_a: PATHGO:0000195 ! proangiogenic response factor
+is_a: PATHGO:0000054 ! synthesis of pathogenicity determinants
 
 [Term]
 id: PATHGO:0000054
-name: virulence factor synthesis
-is_a: PATHGO:0000111 ! process or component of virulence
+name: synthesis of pathogenicity determinants
+is_a: PATHGO:0000111 ! process or component of pathogenicity
 
 [Term]
 id: PATHGO:0000055
-name: cleavage of membrane phospholipids
-is_a: PATHGO:0000118 ! invasion
-property_value: IAO:0000115 "Mechanism of invasion that involves cleaving membrane phospholipids" xsd:string
-
-[Term]
-id: PATHGO:0000056
-name: protease
-is_a: PATHGO:0000073 ! determinant of virulence
-
-[Term]
-id: PATHGO:0000057
-name: lysin
-is_a: PATHGO:0000157 ! cell killing factor
+name: mediates membrane phospholipid cleavage
+is_a: PATHGO:0000029 ! mediates membrane damage
+property_value: editorialNote "evaluate for placement in invasion and dissemination" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates membrane damage by cleavage of membrane phospholipids." xsd:string
 
 [Term]
 id: PATHGO:0000058
-name: iron uptake
-is_a: PATHGO:0000113 ! nutrient uptake
-property_value: IAO:0000115 "Mechanism that involves acquisition of iron" xsd:string
-
-[Term]
-id: PATHGO:0000059
-name: outer membrane protein
-is_a: PATHGO:0000073 ! determinant of virulence
+name: mediates iron uptake
+is_a: PATHGO:0000113 ! mediates nutrient availability or uptake
+property_value: IAO:0000115 "A mechanism of nutrient avialability or uptake that involves acquisition of iron." xsd:string
 
 [Term]
 id: PATHGO:0000060
 name: cytokine response suppression
 is_a: PATHGO:0000075 ! innate immune system subversion
-property_value: IAO:0000115 "Mechanism that involves decreasing or abolishing the production of immune system cytokines" xsd:string
-
-[Term]
-id: PATHGO:0000061
-name: cyclin-dependent kinase 1 inactivator
-is_a: PATHGO:0000157 ! cell killing factor
+property_value: editorialNote "redundant" xsd:string
+property_value: IAO:0000115 "A mechanism of innate immune system subversion that involves decreasing or abolishing the production of immune system cytokines." xsd:string
 
 [Term]
 id: PATHGO:0000062
-name: biofilm formation
-is_a: PATHGO:0000147 ! adherence and colonization
-property_value: editorialNote "Process whereby microorganisms irreversibly attach to and grow on a surface and produce extracellular polymers that facilitate attachment and matrix formation, resulting in an alteration in the phenotype of the organisms with respect to growth rate and gene transcription. (Donlan, Rodney M. \"Biofilm formation: a clinically relevant microbiological process.\" Clinical Infectious Diseases 33.8 (2001): 1387-1392.)" xsd:string
-property_value: IAO:0000115 "Mechanism of colonization that involves synthesis of extracellular polymeric substances in a film" xsd:string
+name: mediates biofilm formation
+is_a: PATHGO:0000147 ! mediates adherence and colonization
+property_value: editorialNote "Process whereby microorganisms irreversibly attach to and grow on a surface and produce extracellular polymers that facilitate attachment and matrix formation, resulting in an alteration in the phenotype of the organisms with respect to growth rate and gene transcription. (Donlan, Rodney M. \"Biofilm formation: a clinically relevant microbiological process.\" Clinical Infectious Diseases 33.8 (2001): 1387-1392.)\n\nMechanism of colonization that involves synthesis of extracellular polymeric substances in a film." xsd:string
+property_value: IAO:0000115 "A mechanism that enables adhesion and colonization by promoting synthesis of extracellular polymeric substances to form a biofilm." xsd:string
 
 [Term]
 id: PATHGO:0000063
-name: lysis of host cells
-is_a: PATHGO:0000121 ! cell killing
+name: disrupts cell cycle
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "Concept covered by GO; GO:0051726; elaborate subclasses" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting the cell cycle of a host cell." xsd:string
 
 [Term]
 id: PATHGO:0000064
-name: adenylate cyclase
-is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+name: second messenger disruption factor
+is_a: PATHGO:0000015 ! cellular signaling disruption factor
+property_value: editorialNote "cyclin-dependent kinase 1 inactivator; calcium- and calmodulin-dependent adenylate cyclase" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts host cellular signaling by modulating levels of second messenger molecules." xsd:string
 
 [Term]
 id: PATHGO:0000065
@@ -351,272 +295,238 @@ is_a: PATHGO:0000071 ! usher-chaperone system
 
 [Term]
 id: PATHGO:0000066
-name: iron acquisition from host
-is_a: PATHGO:0000058 ! iron uptake
-property_value: IAO:0000115 "Mechanism of iron uptake that involves taking iron from a target cell" xsd:string
+name: mediates iron acquisition from host
+is_a: PATHGO:0000058 ! mediates iron uptake
+property_value: IAO:0000115 "A mechanism of iron uptake that involves taking iron from a target cell." xsd:string
 
 [Term]
 id: PATHGO:0000067
-name: nutrient uptake factor
-is_a: PATHGO:0000073 ! determinant of virulence
-
-[Term]
-id: PATHGO:0000068
-name: coagulation cascade modulator
-is_a: PATHGO:0000073 ! determinant of virulence
+name: nutrient availability or uptake factor
+is_a: PATHGO:0000105 ! proliferation and survival factor
+property_value: editorialNote "examples may include: gelatinase, mucinase, sialidase, hyaluronidase - enzymes that are also associated with destruction of extracellular matrix, mucus, etc. to promote invasion and spread in the host \n\nsiderophore-chelate and sequester iron from host\n\nelaborate subclasses; align with mechanism branch" xsd:string
+property_value: IAO:0000115 "A gene product that promotes proliferation and survival by contributing to the availability and/or uptake of nutrients from host cells or the environment." xsd:string
 
 [Term]
 id: PATHGO:0000069
 name: collagen binding protein
-is_a: PATHGO:0000077 ! extracellular matrix binding protein
-
-[Term]
-id: PATHGO:0000070
-name: fimbriae protein
-is_a: PATHGO:0000120 ! adhesin
+is_a: PATHGO:0000077 ! extracellular matrix binding factor
+property_value: IAO:0000115 "A gene product that mediates adhesion through collagen binding." xsd:string
 
 [Term]
 id: PATHGO:0000071
 name: usher-chaperone system
-is_a: PATHGO:0000054 ! virulence factor synthesis
+is_a: PATHGO:0000054 ! synthesis of pathogenicity determinants
 
 [Term]
 id: PATHGO:0000072
 name: glycoprotein binding
-is_a: PATHGO:0000038 ! adherence
-property_value: IAO:0000115 "Mechanism of adherence that involves binding to a sugar-modified surface protein on a target cell" xsd:string
+is_a: PATHGO:0000211 ! mediates cell surface binding
+property_value: editorialNote "evaluate for organizational consistency\n\nA mechanism of cell surface binding that involves binding to a sugar-modified surface protein on a target cell." xsd:string
+property_value: IAO:0000115 "A mechanism that mediates cell surface binding through glycoproteins." xsd:string
 
 [Term]
 id: PATHGO:0000073
-name: determinant of virulence
-comment: Wikipedia: Virulence factors are molecules produced by bacteria, viruses, fungi, and protozoa that add to their effectiveness and enable them to achieve the following: colonization of a niche in the host (this includes attachment to cells) immunoevasion, evasion of the host's immune response immunosuppression, inhibition of the host's immune response entry into and exit out of cells (if the pathogen is an intracellular one) obtain nutrition from the host Specific pathogens possess a wide array of virulence factors. Some are chromosomally encoded and intrinsic to the bacteria (e.g. capsules and endotoxin), whereas others are obtained from mobile genetic elements like plasmids and bacteriophages (e.g. some exotoxins). Virulence factors encoded on mobile genetic elements spread through horizontal gene transfer, and can convert harmless bacteria into dangerous pathogens. Bacteria like Escherichia coli O157:H7 gain the majority of their virulence from mobile genetic elements. Gram-negative bacteria secrete a variety of virulence factors at host-pathogen interface, via membrane vesicle trafficking as bacterial outer membrane vesicles for invasion, nutrition and other cell-cell communications. It has been found that many pathogens have converged on similar virulence factors to battle against eukaryotic host defenses. These obtained bacterial virulence factors have two different routes used to help them survive and grow: The factors are used to assist and promote colonization of the host. These factors include adhesins, invasins, and antiphagocytic factors. The factors, including toxins, hemolysins, and proteases, bring damage to the host.
+name: determinant of pathogenicity
 xref: CHEBI:72316
-is_a: PATHGO:0000111 ! process or component of virulence
-property_value: IAO:0000115 "Any molecule produced by bacteria, viruses, fungi or protozoa enabling them to achieve colonization of a niche in the host, inhibit or evade the host's immune response, enter and exit cells, or obtain nutrition from the host." xsd:string
+is_a: PATHGO:0000111 ! process or component of pathogenicity
+property_value: IAO:0000115 "A molecule produced by microbes (bacteria, viruses, fungi or protozoa) that enables them to achieve colonization of a host, inhibit or evade the host's immune response, enter and exit cells, or obtain nutrition from the host." xsd:string
 
 [Term]
 id: PATHGO:0000074
-name: induction of angiogenesis
-is_a: PATHGO:0000150 ! proliferation and survival
-property_value: IAO:0000115 "Mechanism that involves stimulation of host blood vessel generation, or angiogenesis" xsd:string
+name: mediates induction of angiogenesis
+is_a: PATHGO:0000150 ! mediates proliferation and survival
+property_value: IAO:0000115 "A mechanism that promotes proliferation and survival by stimulation of host blood vessel generation, or angiogenesis." xsd:string
 
 [Term]
 id: PATHGO:0000075
 name: innate immune system subversion
-is_a: PATHGO:0000085 ! immune evasion and subversion
-property_value: IAO:0000115 "Mechanism that involves producing factors that hide a pathogen from the innate immune system, or subvert the ability of the innate immune system to respond to the pathogen." xsd:string
-
-[Term]
-id: PATHGO:0000076
-name: hyaluronidase
-is_a: PATHGO:0000081 ! invasion factor
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: editorialNote "not consistent as a subclass-evaluate for removal; all subclasses to this class are represented as subclasses of 'mediates immune evasion and subversion'" xsd:string
+property_value: IAO:0000115 "A mechanism of immune evasion and subversion that involves producing factors that hide a pathogen from the innate immune system, or subvert the ability of the innate immune system to respond to the pathogen." xsd:string
 
 [Term]
 id: PATHGO:0000077
-name: extracellular matrix binding protein
-is_a: PATHGO:0000120 ! adhesin
-
-[Term]
-id: PATHGO:0000078
-name: intracellular delivery of effector proteins
-is_a: PATHGO:0000014 ! intracellular delivery
-property_value: IAO:0000115 "Mechanism of Intracellular delivery where the factors being delivered are proteins" xsd:string
+name: extracellular matrix binding factor
+is_a: PATHGO:0000120 ! adhesion factor
+property_value: editorialNote "Collagen binding protein and fibronectin binding protein are examples.  Including these as subclasses may be too granular." xsd:string
+property_value: IAO:0000115 "A gene product that mediates adhesion by enabling binding to extracellular matrix components such as collagen and fibronectin." xsd:string
 
 [Term]
 id: PATHGO:0000079
-name: deoxyribonuclease (DNase)
-is_a: PATHGO:0000157 ! cell killing factor
+name: DNA cleavage factor
+synonym: "deoxyribonuclease (DNAse)" RELATED []
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: editorialNote "Target is the macromolecule and not process so this term doesn't fit definition of parent class" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by cleaving DNA." xsd:string
 
 [Term]
 id: PATHGO:0000080
-name: dendritic cell maturation inhibitor
-is_a: PATHGO:0000085 ! immune evasion and subversion
-property_value: IAO:0000115 "Mechanism that blocks immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells" xsd:string
+name: inhibits dendritic cell maturation
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by blocking immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells." xsd:string
 
 [Term]
 id: PATHGO:0000081
-name: invasion factor
-synonym: "invasin" RELATED []
-xref: BVF:0000003
-is_a: PATHGO:0000073 ! determinant of virulence
-property_value: IAO:0000115 "Molecules associated with the penetration of pathogens into host cells" xsd:string
+name: host immune function modulation factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by modulating host immune system components and processes." xsd:string
 
 [Term]
 id: PATHGO:0000082
-name: peptide and protein degradation
-is_a: PATHGO:0000113 ! nutrient uptake
-property_value: IAO:0000115 "Mechanism that involves peptide and protein degradation for the purpose of nutrient acquisition" xsd:string
+name: mediates peptide and protein degradation
+is_a: PATHGO:0000113 ! mediates nutrient availability or uptake
+property_value: editorialNote "overlaps with extracellular matrix destruction under invasion and dissemination" xsd:string
+property_value: IAO:0000115 "A mechanism of nutrient availability or uptake that involves peptide and protein degradation." xsd:string
 
 [Term]
 id: PATHGO:0000083
-name: virulence factor target
-is_a: PATHGO:0000111 ! process or component of virulence
+name: pathogenicity target
+is_a: PATHGO:0000111 ! process or component of pathogenicity
 
 [Term]
 id: PATHGO:0000084
-name: inhibition of lymphocyte proliferation
-is_a: PATHGO:0000085 ! immune evasion and subversion
-property_value: IAO:0000115 "Mechanism that prevents immune system cells from growing via cell division" xsd:string
+name: inhibits lymphocyte proliferation
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by preventing lymphocytes from growing via cell division." xsd:string
 
 [Term]
 id: PATHGO:0000085
-name: immune evasion and subversion
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that involves producing factors that hide a pathogen from the immune system, or that actively counter or subvert host cell immunity" xsd:string
+name: mediates immune evasion and subversion
+is_a: PATHGO:0000016 ! modulates host immune function
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by modulating the availability or function of immune system components to evade or subvert host immune functions." xsd:string
 
 [Term]
 id: PATHGO:0000086
-name: autoinducer synthase
-is_a: PATHGO:0000112 ! quorom sensing system factor
+name: quorum sensing autoinducer production factor
+is_a: PATHGO:0000112 ! quorum sensing system factor
+property_value: editorialNote "autoinducer synthase" xsd:string
+property_value: IAO:0000115 "A gene product that contributes to quorum sensing by promoting production of autoinducer molecules." xsd:string
 
 [Term]
 id: PATHGO:0000087
 name: capsule biosynthesis
-is_a: PATHGO:0000054 ! virulence factor synthesis
+is_a: PATHGO:0000054 ! synthesis of pathogenicity determinants
 
 [Term]
 id: PATHGO:0000088
-name: regulation of host cell signaling
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that alters host cell signaling for pathogenic purposes, whether adherence and colonization, proliferation and survival, invasion, or some other purpose." xsd:string
+name: tight junction modifier
+is_a: PATHGO:0000160 ! cellular adhesion disruption factor
+property_value: editorialNote "example: Clostridium perfringens type A toxin (targets claudins)  more info: https://doi.org/10.1016/j.bbamem.2008.10.028; https://www.ncbi.nlm.nih.gov/pubmed/11595640" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts cellular adhesion by modification of tight junction formation." xsd:string
 
 [Term]
 id: PATHGO:0000089
-name: disruption of mitochondrial membrane potential
-is_a: PATHGO:0000127 ! inhibition of mitochondrial function
+name: disrupts mitochondrial membrane potential
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating the alteration of mitochondrial membrane potential." xsd:string
 
 [Term]
 id: PATHGO:0000090
 name: immune evasion and subversion factor
-is_a: PATHGO:0000073 ! determinant of virulence
-
-[Term]
-id: PATHGO:0000091
-name: calcium- and calmodulin-dependent adenylate cyclase
-is_a: PATHGO:0000064 ! adenylate cyclase
-
-[Term]
-id: PATHGO:0000092
-name: type IV pili
-is_a: PATHGO:0000134 ! type IV secretion system
+is_a: PATHGO:0000081 ! host immune function modulation factor
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by modulating the availability or function of immune system components to evade or subvert host immune functions." xsd:string
 
 [Term]
 id: PATHGO:0000093
 name: coagulation factor V protease
-is_a: PATHGO:0000068 ! coagulation cascade modulator
+is_a: PATHGO:0000194 ! platelet aggregation inhibitor
+property_value: editorialNote "This is an example.  It should be moved as it does not directly impact platelet aggregation, rather it t inhibits coagulation cascade to disrupt coagulation." xsd:string
 
 [Term]
 id: PATHGO:0000094
 name: mitogen-activated protein kinase kinases (MAPKKs) protease
-is_a: PATHGO:0000056 ! protease
-
-[Term]
-id: PATHGO:0000095
-name: surface components
-xref: BVF:0000004
-is_a: PATHGO:0000073 ! determinant of virulence
+is_a: PATHGO:0000015 ! cellular signaling disruption factor
 
 [Term]
 id: PATHGO:0000096
-name: degradation of polysaccharide
-is_a: PATHGO:0000118 ! invasion
-property_value: IAO:0000115 "Mechanism of invasion that involves degradation of polysaccharides" xsd:string
-
-[Term]
-id: PATHGO:0000097
-name: evasion of immune effectors by antigenic variation
-is_a: PATHGO:0000085 ! immune evasion and subversion
-property_value: IAO:0000115 "Mechanism for evading the immune system by varying the sequence or structure of pathogen components targeted by immune cells" xsd:string
-
-[Term]
-id: PATHGO:0000098
-name: small GTPase activating protein
-is_a: PATHGO:0000116 ! regulator of cell signaling
+name: mediates polysaccharide degradation
+is_a: PATHGO:0000029 ! mediates membrane damage
+property_value: editorialNote "evaluate for placement in invasion and dissemination" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates membrane damage by degradation of polysaccharides." xsd:string
 
 [Term]
 id: PATHGO:0000099
-name: binding to extracellular matrix
-is_a: PATHGO:0000038 ! adherence
-property_value: IAO:0000115 "Mechanism of adherence in which attachment occurs to components of the extracellular matrix as opposed to the target cell directly" xsd:string
+name: mediates extracellular matrix binding
+is_a: PATHGO:0000038 ! mediates adhesion
+property_value: editorialNote "Mechanism of adherence in which attachment occurs to components of the extracellular matrix as opposed to the target cell directly;\nelaborate subclasses" xsd:string
+property_value: IAO:0000115 "A mechanism that enables adhesion by mediating binding to extracellular matrix components such as collagen and fibronectin." xsd:string
 
 [Term]
 id: PATHGO:0000100
-name: resistance to complement-mediated killing
-is_a: PATHGO:0000075 ! innate immune system subversion
-property_value: IAO:0000115 "Mechanism that involves avoiding or countering the effects of the complement system, a component of the innate immune system" xsd:string
+name: mediates resistance to complement system
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: editorialNote "resistance to complement-mediated killing" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by countering the effects of the complement system, a component of the innate immune system." xsd:string
 
 [Term]
 id: PATHGO:0000101
 name: lymphocyte proliferation inhibition factor
 is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: definition "A gene product that mediates immune evasion and subversion by preventing lymphocytes from growing via cell division." xsd:string
 
 [Term]
 id: PATHGO:0000102
-name: secretion system factor
-is_a: PATHGO:0000073 ! determinant of virulence
+name: determinant of protein effector secretion
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "The secretion pathways are typically described as \"types\" based on components/structures involved corresponding to variations on a few general strategies involving transport across inner membrane, transport across inner membrane followed by transport across outer membrane (two-step), transport across both membranes. Several types can also transport proteins directly across the host cell membrane to deliver effectors directly into cells\n\nType I- one step to extracellular\nType II- two step, first step is independent transport into periplasm\nType III- spans both membranes, injectosome into host cell\nType IV- spans both membranes, release of effectors into other cell (conjugation)\nType V-autotransporter in OM, first step is independent transport into periplasm\nType VI- spans both membranes, release into other cell\n\nhttps://www.ncbi.nlm.nih.gov/pmc/articles/PMC4804464/\nhttps://www.sciencedirect.com/science/article/pii/S0167488904000783\n\nEvaluate subclass naming/organization" xsd:string
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by contributing to secretion of protein effectors from the bacterial cell into the extracellular environment or directly into the host cell." xsd:string
 
 [Term]
 id: PATHGO:0000103
-name: Toll-like receptor adaptor protein degradation activator
+name: toll-like receptor signaling disruption factor
 is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: definition "A gene product that mediates immune evasion and subversion by disrupting toll-like receptor signaling." xsd:string
+property_value: editorialNote "adaptor protein degradation activator; research and add others" xsd:string
 
 [Term]
 id: PATHGO:0000104
-name: obstruction of antibacterial peptide binding
-is_a: PATHGO:0000085 ! immune evasion and subversion
-property_value: IAO:0000115 "Mechanism that involves preventing antibacterial peptides from binding to their targets" xsd:string
+name: disrupts antimicrobial peptide binding
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by preventing antibacterial peptides from binding to their targets." xsd:string
 
 [Term]
 id: PATHGO:0000105
 name: proliferation and survival factor
-is_a: PATHGO:0000073 ! determinant of virulence
-
-[Term]
-id: PATHGO:0000106
-name: motility
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that allows organisms to move independently, using metabolic energy.  Types of bacterial movement include swimming, swarming, gliding, twitching, and sliding." xsd:string
-
-[Term]
-id: PATHGO:0000107
-name: monocyte/macrophage adherence protein
-is_a: PATHGO:0000120 ! adhesin
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "evaluate placement and provide examples" xsd:string
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by enabling proliferation and/or survival of a pathogen, especially when environmental conditions are unfavorable, not related to adherence and colonization." xsd:string
 
 [Term]
 id: PATHGO:0000108
-name: inhibition of actin polymerization
-is_a: PATHGO:0000121 ! cell killing
-
-[Term]
-id: PATHGO:0000109
-name: sialidase
-is_a: PATHGO:0000067 ! nutrient uptake factor
+name: mediates actin polymerization inhibition
+is_a: PATHGO:0000028 ! disrupts cytoskeleton maintenance
+property_value: IAO:0000115 "A mechanism that disrupts cytoskeleton maintenance by mediating inhibition of actin polymerization." xsd:string
 
 [Term]
 id: PATHGO:0000110
-name: secretion of virulence determinants
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that leads to transport of virulence determinants from inside a pathogen to the extracellular space" xsd:string
+name: mediates secretion of protein effectors
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "elaborate subclasses and align with determinant branch" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by contributing to secretion of protein effectors from the bacterial cell into the extracellular environment or directly into the host cell." xsd:string
 
 [Term]
 id: PATHGO:0000111
-name: process or component of virulence
+name: process or component of pathogenicity
+property_value: IAO:0000115 "Pathogenicity is the ability of microbes to have damaging effects on cells.  A process or component of pathogenicity is an expression that describes how a pathogen exerts its effect on host cells, or through what determinant that effect is achieved." xsd:string
 
 [Term]
 id: PATHGO:0000112
-name: quorom sensing system factor
+name: quorum sensing system factor
 is_a: PATHGO:0000119 ! biofilm formation factor
+property_value: IAO:0000115 "A gene product that promotes biofilm formation by contributing to quorum sensing." xsd:string
 
 [Term]
 id: PATHGO:0000113
-name: nutrient uptake
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that facilitates the uptake of nutrients from host cells or the environment" xsd:string
+name: mediates nutrient availability or uptake
+is_a: PATHGO:0000150 ! mediates proliferation and survival
+property_value: editorialNote "evaluate and modify subclasses to achieve consistent structure; align to determinant branch" xsd:string
+property_value: IAO:0000115 "A mechanism that promotes proliferation and survival by contributing to the availability and/or uptake of nutrients from host cells or the environment." xsd:string
 
 [Term]
 id: PATHGO:0000114
-name: mechanism of virulence
-is_a: PATHGO:0000111 ! process or component of virulence
+name: mechanism of pathogenicity
+is_a: PATHGO:0000111 ! process or component of pathogenicity
+property_value: IAO:0000115 "A process that pathogens perform to have damaging effects on cells, and that specifically describes how that effect is exerted." xsd:string
 
 [Term]
 id: PATHGO:0000115
@@ -625,8 +535,10 @@ is_a: PATHGO:0000117 ! lipopolysaccharide biosynthesis
 
 [Term]
 id: PATHGO:0000116
-name: regulator of cell signaling
-is_a: PATHGO:0000073 ! determinant of virulence
+name: regulator of nitric oxide synthase
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: editorialNote "inappropriate placement; Overlaps with GO (molecular function and regulation of activity terms); evaluate for removal" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by modulating the activity of nitric oxide synthase." xsd:string
 
 [Term]
 id: PATHGO:0000117
@@ -634,208 +546,140 @@ name: lipopolysaccharide biosynthesis
 is_a: PATHGO:0000052 ! surface polysaccharide biosynthesis
 
 [Term]
-id: PATHGO:0000118
-name: invasion
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that allows pathogens to spread within host cells or throughout organisms, and that is distinct from adherence and colonization" xsd:string
-
-[Term]
 id: PATHGO:0000119
 name: biofilm formation factor
 is_a: PATHGO:0000151 ! adherence and colonization factor
+property_value: IAO:0000115 "A gene product that mediates adherence and colonization by promoting synthesis of extracellular polymeric substances to form a biofilm." xsd:string
 
 [Term]
 id: PATHGO:0000120
-name: adhesin
+name: adhesion factor
+synonym: "adhesin" RELATED []
 is_a: PATHGO:0000151 ! adherence and colonization factor
-property_value: IAO:0000115 "Cell-surface components or appendages of bacteria that facilitate adhesion or adherence to other cells or to surfaces, usually the host they are infecting or living in" xsd:string
-
-[Term]
-id: PATHGO:0000121
-name: cell killing
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that results in death of a host orgnanism" xsd:string
+property_value: editorialNote "definition needs to be rewritten\n\nencodes cell-surface or appendage components of bacteria" xsd:string
+property_value: IAO:0000115 "A gene product that facilitates adhesion and colonization by enabling attachment to other cells or to surfaces, usually the host they are infecting or living in." xsd:string
 
 [Term]
 id: PATHGO:0000122
-name: activator of host cell nitric oxide synthase
-is_a: PATHGO:0000073 ! determinant of virulence
-property_value: IAO:0000115 "Leads to high levels of nitric oxide radicals.  Nitric oxide destroys iron-dependent enzymes, eventually inhibiting mitochondrial function and DNA synthesis in nearby host cells." xsd:string
-
-[Term]
-id: PATHGO:0000123
-name: intracellular motility
-is_a: PATHGO:0000106 ! motility
-property_value: IAO:0000115 "Type of motility that occurs inside cells" xsd:string
+name: nitric oxide synthase activator
+is_a: PATHGO:0000116 ! regulator of nitric oxide synthase
+property_value: editorialNote "Overlaps with GO (molecular function and regulation of activity terms)" xsd:string
+property_value: IAO:0000115 "A gene product that activates nitric oxide synthase enzyme  leading to high levels of nitric oxide radicals.  Nitric oxide radicals destroy iron-dependent enzymes, eventually inhibiting mitochondrial function and DNA synthesis in nearby host cells." xsd:string
 
 [Term]
 id: PATHGO:0000124
-name: iron acquisition from environment
-is_a: PATHGO:0000058 ! iron uptake
-property_value: IAO:0000115 "Mechanism of iron uptake that involves using iron in the environment" xsd:string
+name: mediates iron acquisition from environment
+is_a: PATHGO:0000058 ! mediates iron uptake
+property_value: IAO:0000115 "A mechanism of iron uptake that involves using iron in the environment." xsd:string
 
 [Term]
 id: PATHGO:0000125
-name: desiccation resistance
-is_a: PATHGO:0000150 ! proliferation and survival
-property_value: IAO:0000115 "Mechanism that allows that pathogens to survive periods without water, or drought-like conditions" xsd:string
-
-[Term]
-id: PATHGO:0000126
-name: hemolysin
-is_a: PATHGO:0000057 ! lysin
-
-[Term]
-id: PATHGO:0000127
-name: inhibition of mitochondrial function
-is_a: PATHGO:0000164 ! disruption of cellular metabolism
-
-[Term]
-id: PATHGO:0000128
-name: poly-beta-1-6-N-acetylglucosamine (PNAG)
-is_a: PATHGO:0000095 ! surface components
+name: mediates desiccation resistance
+is_a: PATHGO:0000150 ! mediates proliferation and survival
+property_value: IAO:0000115 "A mechanism that promotes proliferation and survival by enabling pathogens to survive periods without water, or drought-like conditions." xsd:string
 
 [Term]
 id: PATHGO:0000129
 name: antiphagocytosis
 is_a: PATHGO:0000075 ! innate immune system subversion
-property_value: IAO:0000115 "Mechanism that prevents phagocytosis of pathogens by immune system cells like macrophages" xsd:string
-
-[Term]
-id: PATHGO:0000130
-name: mucinase
-is_a: PATHGO:0000067 ! nutrient uptake factor
+property_value: editorialNote "redundant" xsd:string
+property_value: IAO:0000115 "A mechanism of innate immune system subversion that prevents phagocytosis of pathogens by immune system cells like macrophages." xsd:string
 
 [Term]
 id: PATHGO:0000131
 name: tight-junction-associated protein occludin redistribution factor
-is_a: PATHGO:0000081 ! invasion factor
+is_a: PATHGO:0000088 ! tight junction modifier
 
 [Term]
 id: PATHGO:0000132
-name: inhibition of DNA synthesis
-is_a: PATHGO:0000121 ! cell killing
+name: mediates DNA synthesis inhibition
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating inhibition of DNA synthesis." xsd:string
 
 [Term]
 id: PATHGO:0000133
 name: fibronectin binding protein
-is_a: PATHGO:0000077 ! extracellular matrix binding protein
+is_a: PATHGO:0000077 ! extracellular matrix binding factor
+property_value: IAO:0000115 "A gene product that mediates adhesion through fibronectin binding." xsd:string
 
 [Term]
 id: PATHGO:0000134
-name: type IV secretion system
-is_a: PATHGO:0000102 ! secretion system factor
+name: determinant of type IV secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000135
-name: deoxyribonuclease activity
-is_a: PATHGO:0000121 ! cell killing
-
-[Term]
-id: PATHGO:0000136
-name: integrin αMβ2 binding protein
-is_a: PATHGO:0000051 ! integrin binding protein
-
-[Term]
-id: PATHGO:0000137
-name: RND-type efflux system
-is_a: PATHGO:0000102 ! secretion system factor
-
-[Term]
-id: PATHGO:0000138
-name: induction of apoptosis
-is_a: PATHGO:0000121 ! cell killing
-is_a: PATHGO:0000169 ! regulation of apoptosis
-
-[Term]
-id: PATHGO:0000139
-name: systemic motility
-is_a: PATHGO:0000106 ! motility
-property_value: IAO:0000115 "Type of motility that occurs through an organism" xsd:string
+name: mediates DNA cleavage
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating cleavage of DNA." xsd:string
 
 [Term]
 id: PATHGO:0000140
-name: type II secretion system
-is_a: PATHGO:0000102 ! secretion system factor
+name: determinant of type II secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000141
-name: type III secretion system
-is_a: PATHGO:0000102 ! secretion system factor
+name: determinant of type III secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000142
-name: acquisition of cholesterol from membrane
-is_a: PATHGO:0000113 ! nutrient uptake
-property_value: IAO:0000115 "Mechanism that involves taking cholesterol from the membranes of target cells" xsd:string
-
-[Term]
-id: PATHGO:0000143
-name: disruption of epithelial cell barrier function
-is_a: PATHGO:0000118 ! invasion
-property_value: IAO:0000115 "Mechanism of invasion that involves disrupting the barrier function of epithelial cell layers" xsd:string
+name: mediates acquisition of cholesterol from membrane
+is_a: PATHGO:0000113 ! mediates nutrient availability or uptake
+property_value: IAO:0000115 "A mechanism that mediates nutrient availability or uptake by taking cholesterol from the membranes of target cells." xsd:string
 
 [Term]
 id: PATHGO:0000144
 name: mitochondrial membrane potential disruption factor
-is_a: PATHGO:0000157 ! cell killing factor
-
-[Term]
-id: PATHGO:0000145
-name: lipopolysaccharide (LPS)
-xref: BVF:0000028
-is_a: PATHGO:0000095 ! surface components
-property_value: http://purl.org/dc/elements/1.1/description "Lipid-containing polysaccharides which are endotoxins and important group-specific antigens. They are often derived from the cell wall of gram-negative bacteria and induce immunoglobulin secretion. The lipopolysaccharide molecule consists of three parts: LIPID A, core polysaccharide, and O-specific chains ( O ANTIGENS). When derived from Escherichia coli, lipopolysaccharides serve as polyclonal B-cell mitogens commonly used in laboratory immunology. (From Dorland, 28th ed)." xsd:string
-
-[Term]
-id: PATHGO:0000146
-name: sialyl Lewis x binding protein
-is_a: PATHGO:0000081 ! invasion factor
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by disrupting the membrane potential of the mitochondria." xsd:string
 
 [Term]
 id: PATHGO:0000147
-name: adherence and colonization
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that enables viruses and bacteria to attach to host cells and establish growth" xsd:string
-
-[Term]
-id: PATHGO:0000148
-name: integrin α2β1 binding protein
-is_a: PATHGO:0000051 ! integrin binding protein
+name: mediates adherence and colonization
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "\"enables adherence and colonization\"" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by enabling pathogens to attach to host cells and establish growth." xsd:string
 
 [Term]
 id: PATHGO:0000149
-name: polysaccharide degradation
-is_a: PATHGO:0000113 ! nutrient uptake
-property_value: IAO:0000115 "Mechanism that involves polysaccharide degradation for the purpose of nutrient acquisition" xsd:string
+name: mediates polysaccharide degradation
+is_a: PATHGO:0000113 ! mediates nutrient availability or uptake
+property_value: editorialNote "this is not consistent with \"mediates uptake\"" xsd:string
+property_value: IAO:0000115 "A mechanism of nutrient availability or uptake that involves polysaccharide degradation." xsd:string
 
 [Term]
 id: PATHGO:0000150
-name: proliferation and survival
-is_a: PATHGO:0000114 ! mechanism of virulence
-property_value: IAO:0000115 "Mechanism that allows pathogens to grow and multiply, distinct from adherence and colonization and/or invasion" xsd:string
+name: mediates proliferation and survival
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by allowing pathogens to grow and multiply, especially when environmental conditions are unfavorable, distinct from adherence and colonization." xsd:string
 
 [Term]
 id: PATHGO:0000151
 name: adherence and colonization factor
 xref: BVF:0000002
-is_a: PATHGO:0000073 ! determinant of virulence
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by enabling pathogens to attach to host cells and establish growth." xsd:string
 
 [Term]
 id: PATHGO:0000152
-name: induction of cell cycle arrest
-is_a: PATHGO:0000121 ! cell killing
+name: induces cell cycle arrest
+is_a: PATHGO:0000063 ! disrupts cell cycle
+property_value: editorialNote "overlap with GO:0007050" xsd:string
 
 [Term]
 id: PATHGO:0000153
-name: complement component 1 (C1) protease
+name: complement system inhibition factor
 is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: definition "A gene product that mediates immune evasion and subversion by inhibiting complement system function." xsd:string
+property_value: editorialNote "example:component 1 (C1) protease" xsd:string
 
 [Term]
 id: PATHGO:0000154
-name: manganese uptake
-is_a: PATHGO:0000113 ! nutrient uptake
-property_value: IAO:0000115 "Mechanism that involves acquisition of manganese" xsd:string
+name: mediates manganese uptake
+is_a: PATHGO:0000113 ! mediates nutrient availability or uptake
+property_value: IAO:0000115 "A mechanism of nutrient availability or uptake that involves acquisition of manganese." xsd:string
 
 [Term]
 id: PATHGO:0000155
@@ -844,197 +688,526 @@ is_a: PATHGO:0000087 ! capsule biosynthesis
 
 [Term]
 id: PATHGO:0000156
-name: type VI secretion system
-is_a: PATHGO:0000102 ! secretion system factor
-
-[Term]
-id: PATHGO:0000157
-name: cell killing factor
-is_a: PATHGO:0000073 ! determinant of virulence
-property_value: editorialNote "Not a very information rich term!" xsd:string
-
-[Term]
-id: PATHGO:0000158
-name: gelatinase
-is_a: PATHGO:0000067 ! nutrient uptake factor
+name: determinant of type VI secretion
+is_a: PATHGO:0000102 ! determinant of protein effector secretion
 
 [Term]
 id: PATHGO:0000159
-name: disruption of cellular adhesion
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: disrupts cellular adhesion
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "evaluate for incorporation to invasion and dissemination\n\nelaborate subclasses" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting the adhesion of cells to other cells and/or extracellular matrix components." xsd:string
 
 [Term]
 id: PATHGO:0000160
 name: cellular adhesion disruption factor
-is_a: PATHGO:0000004 ! determinant of toxicity
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "evaluate for incorporation into invasion and dissemination; elaborate subclasses" xsd:string
+property_value: IAO:0000115 "A gene product that confers toxicity by disrupting adhesion between cells or between cells and extracellular matrix components." xsd:string
 
 [Term]
 id: PATHGO:0000161
 name: mucosal barrier disruption
-is_a: PATHGO:0000162 ! epithelial layer disruption
+synonym: "gastrointestinal barrier disruption" RELATED []
+is_a: PATHGO:0000159 ! disrupts cellular adhesion
+property_value: editorialNote "higher level process, not appropriate subclass; evaluate for removal or alternate placement; revise definition" xsd:string
+property_value: IAO:0000115 "A mechanism that compromises the intestinal mucosal barrier, permitting microbial products and/or microbes entry into the body.  The intestinal mucosal barrier consists of the intestinal epithelial layer, plus additional physical, biochemical, and immunological components." xsd:string
 
 [Term]
 id: PATHGO:0000162
 name: epithelial layer disruption
-is_a: PATHGO:0000159 ! disruption of cellular adhesion
-
-[Term]
-id: PATHGO:0000163
-name: intercellular tight junction modifier
-is_a: PATHGO:0000160 ! cellular adhesion disruption factor
+is_a: PATHGO:0000159 ! disrupts cellular adhesion
+property_value: editorialNote "higher level process, not appropriate subclass; evaluate for removal or alternate placement" xsd:string
+property_value: IAO:0000115 "A mechanism that compromises epithelial cell layers, enabling increased permeation of biomolecules and/or bacterial invasion." xsd:string
 
 [Term]
 id: PATHGO:0000164
-name: disruption of cellular metabolism
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: disrupts cellular metabolism
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting cellular processes involved in the synthesis or breakdown of cellular constituents or production of energy." xsd:string
 
 [Term]
 id: PATHGO:0000165
-name: regulation of cellular signaling
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: disrupts host cellular signaling
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "refine/build out subclasses and align to determinant branch" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting host cellular signaling processes." xsd:string
 
 [Term]
 id: PATHGO:0000166
-name: disruption of cellular structure
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: disrupts cellular structure
+synonym: "lysis of host cells" RELATED []
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting the structural integrity of a cell." xsd:string
 
 [Term]
 id: PATHGO:0000167
-name: disruption of cellular transport
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: disrupts cellular transport
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "elaborate and restructure subclasses using a consistent organizational principle\n\nexample concepts to consider in determining organization:\nmembrane transport\nvesicular transport\nendocytosis/exocytosis\nactive/passive\nintracellular trafficking\nmicrotubule mediated transport" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by disrupting transport of products into, out of, and within host cells." xsd:string
 
 [Term]
 id: PATHGO:0000168
-name: enzyme inhibition
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: mediates enzyme inhibition
+is_a: PATHGO:0000165 ! disrupts host cellular signaling
+property_value: editorialNote "evaluate for placement and provide examples; disambiguate from mediates metabolic enzyme inhibition; revise definition" xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts host cell signaling by inhibiting cellular enzymes. For inhibition of metabolic enzymes, see terms under 'disruption of cellular metabolism'." xsd:string
 
 [Term]
 id: PATHGO:0000169
-name: regulation of apoptosis
-is_a: PATHGO:0000036 ! mechanism of toxicity
+name: regulates apoptosis
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: editorialNote "Evaluate for placement in proliferation and survival\n\nConcept covered by GO; GO:0042981" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by impacting host cell apoptosis. Gene products produced by pathogenic microbes may induce or prevent apoptosis to enable growth inside the host." xsd:string
 
 [Term]
 id: PATHGO:0000170
-name: disruption of cellular cAMP levels
-is_a: PATHGO:0000164 ! disruption of cellular metabolism
+name: disrupts cellular cAMP levels
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: editorialNote "redundant to cellular signaling \"second messenger disruption\"; should be moved; evaluate subclasses" xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by altering the levels of cyclic adenosine monophosphate (cyclic AMP, or cAMP) in cells.  Cyclic AMP is a second messenger molecule that regulates physiological processes in cells, through, for example, activation of intracellular signaling pathways." xsd:string
 
 [Term]
 id: PATHGO:0000171
-name: production of reactive oxygen species
-is_a: PATHGO:0000164 ! disruption of cellular metabolism
+name: mediates reactive oxygen species production
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: editorialNote "should be moved as it is not a logical subclass for 'disrupts cellular metabolism'" xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating production of reactive oxygen species." xsd:string
 
 [Term]
 id: PATHGO:0000172
 name: nitric oxide radical production
-is_a: PATHGO:0000171 ! production of reactive oxygen species
+is_a: PATHGO:0000171 ! mediates reactive oxygen species production
+property_value: editorialNote "evaluate placement; not appropriate subclass" xsd:string
 
 [Term]
 id: PATHGO:0000173
-name: cAMP synthesis
-is_a: PATHGO:0000170 ! disruption of cellular cAMP levels
+name: modulates cAMP synthesis
+is_a: PATHGO:0000170 ! disrupts cellular cAMP levels
+property_value: IAO:0000115 "A mechanism that disrupts cellular cAMP levels through activation of the production or repression of the breakdown of cAMP." xsd:string
 
 [Term]
 id: PATHGO:0000174
-name: regulation of host cell adenylate cyclases/phosphodiesterases
-is_a: PATHGO:0000170 ! disruption of cellular cAMP levels
+name: regulates host cell adenylate cyclases/phosphodiesterases
+is_a: PATHGO:0000170 ! disrupts cellular cAMP levels
+property_value: editorialNote "evaluate for redundancy with \"modulates cAMP synthesis\"" xsd:string
 
 [Term]
 id: PATHGO:0000175
-name: disruption of G-protein signaling pathways
-is_a: PATHGO:0000165 ! regulation of cellular signaling
+name: disrupts G-protein signaling pathways
+is_a: PATHGO:0000165 ! disrupts host cellular signaling
+property_value: IAO:0000115 "A mechanism that disprupts host cell signaling by interfering with host G-protien siignaling pathways." xsd:string
 
 [Term]
 id: PATHGO:0000176
 name: regulation of receptor activity
-is_a: PATHGO:0000165 ! regulation of cellular signaling
+is_a: PATHGO:0000165 ! disrupts host cellular signaling
 
 [Term]
 id: PATHGO:0000177
-name: modulation of second messenger molecules
-is_a: PATHGO:0000165 ! regulation of cellular signaling
+name: modulates second messenger molecules
+is_a: PATHGO:0000165 ! disrupts host cellular signaling
+property_value: IAO:0000115 "A mechanism that disrupts host cellular signaling by modulating levels of second messenger molecules." xsd:string
 
 [Term]
 id: PATHGO:0000178
 name: suppression of apoptosis
-is_a: PATHGO:0000169 ! regulation of apoptosis
+is_a: PATHGO:0000169 ! regulates apoptosis
 
 [Term]
 id: PATHGO:0000179
 name: cellular metabolism disruption factor
-is_a: PATHGO:0000004 ! determinant of toxicity
-
-[Term]
-id: PATHGO:0000180
-name: nitric oxide synthase inhibitor
-is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that confers pathogenicity by disrupting cellular processes involved in the synthesis or breakdown of cellular constituents or production of energy." xsd:string
 
 [Term]
 id: PATHGO:0000181
 name: GTPase activating protein
-is_a: PATHGO:0000015 ! cellular signaling regulation factor
+is_a: PATHGO:0000015 ! cellular signaling disruption factor
 
 [Term]
 id: PATHGO:0000182
 name: cellular structure disruption factor
-is_a: PATHGO:0000004 ! determinant of toxicity
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by disrupting structural components of cells." xsd:string
 
 [Term]
 id: PATHGO:0000183
 name: cytoskeleton disruption factor
 is_a: PATHGO:0000182 ! cellular structure disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cellular structure by disrupting components of the cytoskeleton." xsd:string
 
 [Term]
 id: PATHGO:0000184
 name: actin crosslinker
 is_a: PATHGO:0000183 ! cytoskeleton disruption factor
+relationship: PATHGO:0000243 PATHGO:0000217 ! participates_in mediates actin crosslinking
+property_value: IAO:0000115 "A gene product that disrupts cytoskeleton structure by crosslinking actin." xsd:string
 
 [Term]
 id: PATHGO:0000185
 name: actin depolymerization factor
 is_a: PATHGO:0000183 ! cytoskeleton disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cytoskeleton structure by depolymerizing actin." xsd:string
 
 [Term]
 id: PATHGO:0000186
 name: actin polymerization inhibition factor
 is_a: PATHGO:0000183 ! cytoskeleton disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cytoskeleton structure by inhibiting actin polymerization." xsd:string
 
 [Term]
 id: PATHGO:0000187
 name: determinant of sphingomyelinase activity
 is_a: PATHGO:0000193 ! determinant of phospholipid cleavage
+property_value: editorialNote "evaluate for removal, concept covered by GO" xsd:string
 
 [Term]
 id: PATHGO:0000188
 name: cellular transport disruption factor
-is_a: PATHGO:0000004 ! determinant of toxicity
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: editorialNote "elaborate and restructure subclasses" xsd:string
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by disrupting transport of products into, out of, and within host cells." xsd:string
 
 [Term]
 id: PATHGO:0000189
-name: determinant of enzyme inhibition
-is_a: PATHGO:0000004 ! determinant of toxicity
+name: metabolic enzyme inhibition factor
+is_a: PATHGO:0000179 ! cellular metabolism disruption factor
+property_value: editorialNote "Need examples.  Concept covered by GO." xsd:string
+property_value: IAO:0000115 "A gene product that disrupts cellular metabolism by mediating metabolic enzyme inhibition." xsd:string
 
 [Term]
 id: PATHGO:0000190
 name: chloride ion channel activator
 is_a: PATHGO:0000191 ! ion channel activity modulator
+property_value: editorialNote "Concept covered by GO, evaluate for removal" xsd:string
 
 [Term]
 id: PATHGO:0000191
 name: ion channel activity modulator
-is_a: PATHGO:0000040 ! ion gradient modulator
+is_a: PATHGO:0000188 ! cellular transport disruption factor
+property_value: editorialNote "not a consistent subclass; evaluate for better alignment" xsd:string
+property_value: IAO:0000115 "A gene product that disrupts cellular transport by modulating ion channel activity." xsd:string
 
 [Term]
 id: PATHGO:0000192
-name: determinant of apoptosis modulation
-is_a: PATHGO:0000004 ! determinant of toxicity
+name: regulation of apoptosis factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by regulating host cell apoptosis. Gene products produced by pathogenic microbes may induce or prevent apoptosis to enable growth inside the host." xsd:string
 
 [Term]
 id: PATHGO:0000193
 name: determinant of phospholipid cleavage
 is_a: PATHGO:0000043 ! determinant of membrane damage
+property_value: IAO:0000115 "A gene product that mediates membrane damage by cleavage of membrane phospholipids." xsd:string
+
+[Term]
+id: PATHGO:0000194
+name: platelet aggregation inhibitor
+is_a: PATHGO:0000160 ! cellular adhesion disruption factor
+property_value: editorialNote "example: disintegrins\n\nevaluate as appropriate subclass, this is specific case of disrupting cellular adhesion; more appropriate class may be \"integrin-dependent adhesion disruption factor\"" xsd:string
+property_value: IAO:0000115 "A gene product that mediates toxicity by impairing platelet adhesion." xsd:string
 
 [Term]
 id: PATHGO:0000195
 name: proangiogenic response factor
 is_a: PATHGO:0000105 ! proliferation and survival factor
+property_value: editorialNote "example VEGF\n\nevaluate proangiogenic response as a contribution to pathogenesis" xsd:string
+property_value: IAO:0000115 "A gene product that promotes proliferation and survival by inducing a proangiogenic response." xsd:string
+
+[Term]
+id: PATHGO:0000196
+name: determinant of extracellular matrix destruction
+is_a: PATHGO:0000210 ! invasion and dissemination factor
+property_value: editorialNote "gelatinase, mucinase, sialidase, hyaluronidase, etc." xsd:string
+property_value: IAO:0000115 "A gene product that mediates invasion and dissemination by promoting destruction of extracellular matrix components." xsd:string
+
+[Term]
+id: PATHGO:0000197
+name: adhesion appendage component
+is_a: PATHGO:0000120 ! adhesion factor
+property_value: editorialNote "Fimbriae proteins/subunits are examples.  \n\nIntended to capture components that are not directly adhesins, but this class may not be structurally consistent." xsd:string
+property_value: IAO:0000115 "A gene product that mediates adhesion by contributing to the structure of an adhesion appendage." xsd:string
+
+[Term]
+id: PATHGO:0000198
+name: cell surface binding factor
+is_a: PATHGO:0000120 ! adhesion factor
+property_value: editorialNote "sialyl Lewis x binding protein is an example\n\nbuild out subclasses" xsd:string
+property_value: IAO:0000115 "A gene product that mediates adhesion by enabling binding to cell surface receptors or components." xsd:string
+
+[Term]
+id: PATHGO:0000199
+name: host cell endomembrane system disruption factor
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by manipulating the host cell endomembrane system." xsd:string
+
+[Term]
+id: PATHGO:0000200
+name: determinant of phagosome escape
+is_a: PATHGO:0000199 ! host cell endomembrane system disruption factor
+
+[Term]
+id: PATHGO:0000201
+name: lysosome lysis evasion factor
+is_a: PATHGO:0000199 ! host cell endomembrane system disruption factor
+
+[Term]
+id: PATHGO:0000202
+name: phagosome acidification disruption factor
+is_a: PATHGO:0000199 ! host cell endomembrane system disruption factor
+
+[Term]
+id: PATHGO:0000203
+name: phagosome maturation disruption factor
+is_a: PATHGO:0000199 ! host cell endomembrane system disruption factor
+
+[Term]
+id: PATHGO:0000204
+name: phagolysosome fusion disruption factor
+is_a: PATHGO:0000199 ! host cell endomembrane system disruption factor
+
+[Term]
+id: PATHGO:0000205
+name: antimicrobial peptide evasion factor
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by enabling evasion of antimicrobial peptides." xsd:string
+
+[Term]
+id: PATHGO:0000206
+name: free radical detoxification determinant
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by detoxifying free radicals." xsd:string
+
+[Term]
+id: PATHGO:0000207
+name: inflammatory cytokine release suppression factor
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by suppressing release of inflammatory cytokines." xsd:string
+
+[Term]
+id: PATHGO:0000208
+name: opsonization inhibition factor
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by inhibiting opsonization, the process by which particles are targeted for phagocytosis." xsd:string
+
+[Term]
+id: PATHGO:0000209
+name: phagocytosis inhibition factor
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by inhibiting phagocytosis." xsd:string
+
+[Term]
+id: PATHGO:0000210
+name: invasion and dissemination factor
+synonym: "invasin" RELATED []
+synonym: "spreading factor" RELATED []
+is_a: PATHGO:0000073 ! determinant of pathogenicity
+property_value: IAO:0000115 "A gene product that mediates pathogenicity by facilitating movement into and through host tissues or cells." xsd:string
+
+[Term]
+id: PATHGO:0000211
+name: mediates cell surface binding
+is_a: PATHGO:0000038 ! mediates adhesion
+property_value: editorialNote "elaborate subclasses" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates adhesion by enabling binding to cell surface receptors or components." xsd:string
+
+[Term]
+id: PATHGO:0000212
+name: mediates quorum sensing
+is_a: PATHGO:0000062 ! mediates biofilm formation
+property_value: IAO:0000115 "A mechanism that enables biofilm formation by contributing to quorum sensing." xsd:string
+
+[Term]
+id: PATHGO:0000213
+name: platelet aggregation inhibition
+is_a: PATHGO:0000159 ! disrupts cellular adhesion
+property_value: editorialNote "not an appropriate subclass as this is a specific example, evaluate for class related to inhibition of integrin mediated adhesion" xsd:string
+
+[Term]
+id: PATHGO:0000214
+name: tight junction modification
+is_a: PATHGO:0000159 ! disrupts cellular adhesion
+property_value: IAO:0000115 "A mechanism that disrupts cellular adhesion by modulating formation of tight junctions." xsd:string
+
+[Term]
+id: PATHGO:0000215
+name: mediates metabolic enzyme inhibition
+is_a: PATHGO:0000164 ! disrupts cellular metabolism
+property_value: editorialNote "provide examples" xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cellular metabolism by mediating inhibition of metabolic enzymes." xsd:string
+
+[Term]
+id: PATHGO:0000216
+name: mediates actin depolymerization
+is_a: PATHGO:0000028 ! disrupts cytoskeleton maintenance
+property_value: IAO:0000115 "A mechanism that disrupts cytoskeleton maintenance by mediating actin depolymerization." xsd:string
+
+[Term]
+id: PATHGO:0000217
+name: mediates actin crosslinking
+is_a: PATHGO:0000028 ! disrupts cytoskeleton maintenance
+property_value: IAO:0000115 "A mechanism that disrupts cytoskeleton maintenance by promoting actin crosslinking." xsd:string
+
+[Term]
+id: PATHGO:0000218
+name: dendritic cell maturation inhibitor
+is_a: PATHGO:0000090 ! immune evasion and subversion factor
+property_value: IAO:0000115 "A gene product that mediates immune evasion and subversion by blocking immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells." xsd:string
+
+[Term]
+id: PATHGO:0000219
+name: desiccation resistance factor
+is_a: PATHGO:0000105 ! proliferation and survival factor
+property_value: IAO:0000115 "A gene product that promotes proliferation and survival by enabling pathogens to survive periods without water, or drought-like conditions." xsd:string
+
+[Term]
+id: PATHGO:0000220
+name: suppresses inflammatory cytokine release
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by suppressing release of inflammatory cytokines." xsd:string
+
+[Term]
+id: PATHGO:0000221
+name: mediates microtubule stabilization
+is_a: PATHGO:0000028 ! disrupts cytoskeleton maintenance
+property_value: editorialNote https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3625037/ xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cytoskeleton maintenance by mediating microtubule stabilization." xsd:string
+
+[Term]
+id: PATHGO:0000222
+name: mediates microtubule destabilization
+is_a: PATHGO:0000028 ! disrupts cytoskeleton maintenance
+property_value: editorialNote https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3625037/ xsd:string
+property_value: IAO:0000115 "A mechanism that disrupts cytoskeleton maintenance by mediating microtubule destabilization." xsd:string
+
+[Term]
+id: PATHGO:0000223
+name: microtubule stabilization factor
+is_a: PATHGO:0000183 ! cytoskeleton disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cytoskeleton structure by stabilizing microtubules." xsd:string
+
+[Term]
+id: PATHGO:0000224
+name: microtubule destabilization factor
+is_a: PATHGO:0000183 ! cytoskeleton disruption factor
+property_value: IAO:0000115 "A gene product that disrupts cytoskeleton structure by destabilizing microtubules." xsd:string
+
+[Term]
+id: PATHGO:0000225
+name: contributes to adhesion appendage formation
+is_a: PATHGO:0000038 ! mediates adhesion
+property_value: IAO:0000115 "A mechanism that mediates adhesion by contributing to the formation of an adhesion appendage." xsd:string
+
+[Term]
+id: PATHGO:0000226
+name: disrupts extracellular matrix
+is_a: PATHGO:0000235 ! mediates invasion and dissemination
+property_value: IAO:0000115 "A mechanism that mediates invasion and dissemination by disrupting extracellular matrix components." xsd:string
+
+[Term]
+id: PATHGO:0000227
+name: determinant of polysaccharide degradation
+is_a: PATHGO:0000043 ! determinant of membrane damage
+property_value: IAO:0000115 "A gene product that mediates membrane damage by degradation of polysaccharides." xsd:string
+
+[Term]
+id: PATHGO:0000228
+name: disrupts second messenger levels
+is_a: PATHGO:0000165 ! disrupts host cellular signaling
+property_value: IAO:0000115 "A mechanism that disrupts host cellular signaling by modulating levels of second messenger molecules." xsd:string
+
+[Term]
+id: PATHGO:0000229
+name: mediates quorum sensing autoinducer production
+is_a: PATHGO:0000212 ! mediates quorum sensing
+property_value: editorialNote "autoinducer synthase" xsd:string
+property_value: IAO:0000115 "A mechanism that contributes to quorum sensing by promoting production of autoinducer molecules." xsd:string
+
+[Term]
+id: PATHGO:0000230
+name: mediates free radical detoxification
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by detoxifying free radicals." xsd:string
+
+[Term]
+id: PATHGO:0000231
+name: inhibits opsonization
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by inhibiting opsonization, the process by which particles are targeted for phagocytosis." xsd:string
+
+[Term]
+id: PATHGO:0000232
+name: inhibits phagocytosis
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by inhibiting phagocytosis." xsd:string
+
+[Term]
+id: PATHGO:0000233
+name: disrupts toll-like receptor signaling
+is_a: PATHGO:0000085 ! mediates immune evasion and subversion
+property_value: IAO:0000115 "A mechanism that mediates immune evasion and subversion by disrupting toll-like receptor signaling." xsd:string
+
+[Term]
+id: PATHGO:0000234
+name: mediates integrin binding
+comment: A mechanism that mediates cell surface binding through integrins.
+is_a: PATHGO:0000211 ! mediates cell surface binding
+
+[Term]
+id: PATHGO:0000235
+name: mediates invasion and dissemination
+comment: A mechanism that mediates pathogenicity by facilitating movement into and through host tissues or cells.
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+
+[Term]
+id: PATHGO:0000236
+name: disrupts host cell endomembrane system
+is_a: PATHGO:0000114 ! mechanism of pathogenicity
+property_value: IAO:0000115 "A mechanism that mediates pathogenicity by manipulating the host cell endomembrane system." xsd:string
+
+[Term]
+id: PATHGO:0000237
+name: mediates phagosome escape
+is_a: PATHGO:0000236 ! disrupts host cell endomembrane system
+
+[Term]
+id: PATHGO:0000238
+name: mediates evasion of lysosome lysis
+is_a: PATHGO:0000236 ! disrupts host cell endomembrane system
+
+[Term]
+id: PATHGO:0000239
+name: disrupts phagolysosome fusion
+is_a: PATHGO:0000236 ! disrupts host cell endomembrane system
+
+[Term]
+id: PATHGO:0000240
+name: disrupts phagosome acidification
+is_a: PATHGO:0000236 ! disrupts host cell endomembrane system
+
+[Term]
+id: PATHGO:0000241
+name: disrupts phagosome maturation
+is_a: PATHGO:0000236 ! disrupts host cell endomembrane system
+
+[Term]
+id: PATHGO:0000242
+name: host vitronectin-binding
+is_a: PATHGO:0000099 ! mediates extracellular matrix binding
+property_value: editorialNote "Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)" xsd:string
+property_value: IAO:0000115 "A mechanism that mediates extracellular matrix binding by adhering specifically to vitronectin" xsd:string
+
+[Term]
+id: PATHGO:0000244
+name: mediates elongation factor 1 inactivation
+is_a: PATHGO:0000006 ! mediates protein synthesis inhibition
+property_value: definition "A mechanism that mediates protein synthesis inhibition by inactivation of elongation factor 1." xsd:string
+property_value: editorialNote "examples Legionella glycosylating toxins and SidI, SARS-CoV N protein" xsd:string
+
+[Typedef]
+id: PATHGO:0000243
+name: participates_in
+is_inverse_functional: true
 

--- a/pathgo.owl
+++ b/pathgo.owl
@@ -11,7 +11,13 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/PATHGO">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/pathgo/releases/2019-02-21/pathgo.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/pathgo/releases/2020-09-03/pathgo.owl"/>
+        <rdfs:comment>©2020 The Johns Hopkins University Applied Physics Laboratory LLC (JHU/APL).  All Rights Reserved.
+
+This material may be only be used, modified, or reproduced by or for the U.S. Government pursuant to the license rights granted under the clauses at DFARS 252.227-7013/7014 or FAR 52.227-14. For any other permission, please contact the Office of Technology Transfer at JHU/APL.
+
+NO WARRANTY, NO LIABILITY. THIS MATERIAL IS PROVIDED “AS IS.” JHU/APL MAKES NO REPRESENTATION OR WARRANTY WITH RESPECT TO THE PERFORMANCE OF THE MATERIALS, INCLUDING THEIR SAFETY, EFFECTIVENESS, OR COMMERCIAL VIABILITY, AND DISCLAIMS ALL WARRANTIES IN THE MATERIAL, WHETHER EXPRESS OR IMPLIED, INCLUDING (BUT NOT LIMITED TO) ANY AND ALL IMPLIED WARRANTIES OF PERFORMANCE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT OF INTELLECTUAL PROPERTY OR OTHER THIRD PARTY RIGHTS. ANY USER OF THE MATERIAL ASSUMES THE ENTIRE RISK AND LIABILITY FOR USING THE MATERIAL. IN NO EVENT SHALL JHU/APL BE LIABLE TO ANY USER OF THE MATERIAL FOR ANY ACTUAL, INDIRECT, CONSEQUENTIAL, SPECIAL OR OTHER DAMAGES ARISING FROM THE USE OF, OR INABILITY TO USE, THE MATERIAL, INCLUDING, BUT NOT LIMITED TO, ANY DAMAGES FOR LOST PROFITS.</rdfs:comment>
+        <rdfs:comment>This material is licensed to the public under CC BY-NC 4.0.  The U.S. Government has “Unlimited Rights” as granted and defined under FAR 52.227-14.</rdfs:comment>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathogenesis gene ontology</rdfs:comment>
     </owl:Ontology>
     
@@ -33,6 +39,12 @@
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/pathgo/IAO_0000115">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
     </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
     
 
 
@@ -130,9 +142,36 @@
     
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#definition -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#editorialNote -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#editorialNote"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000243 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000243">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:label xml:lang="en">participates_in</rdfs:label>
+    </owl:ObjectProperty>
     
 
 
@@ -152,6 +191,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000193"/>
         <rdfs:label>determinant of phospholipase activity</rdfs:label>
+        <skos:editorialNote>evaluate for removal, concept covered by GO</skos:editorialNote>
     </owl:Class>
     
 
@@ -160,8 +200,11 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000034"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that inhibits protein synthesis by inactivation of elongation factor 2.</pathgo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elongation factor 2 inactivator</rdfs:label>
-        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">examples diphtheria toxin and Pseudomonas exotoxin A</skos:editorialNote>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">examples diphtheria toxin and Pseudomonas exotoxin A
+
+Regulation of enzyme activity concepts are covered by GO.</skos:editorialNote>
     </owl:Class>
     
 
@@ -170,7 +213,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000167"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ion transport modulation</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular transport by modulating ion channel activity.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates ion channel activity modulation</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">direct action on ion channel (voltage or ligand gated) or ion pump,</skos:editorialNote>
     </owl:Class>
     
@@ -179,9 +223,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">New definition for determinant of toxicity, with more detail</pathgo:IAO_0000115>
-        <rdfs:label>determinant of toxicity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by disrupting the cell cycle of a host cell.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of cell cycle factor</rdfs:label>
+        <skos:editorialNote>Elaborate subclasses and document examples</skos:editorialNote>
     </owl:Class>
     
 
@@ -190,7 +235,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000035"/>
-        <rdfs:label>determinant of non-specific T cell activation</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-specific T cell activation factor</rdfs:label>
+        <skos:editorialNote>superantigens</skos:editorialNote>
     </owl:Class>
     
 
@@ -198,8 +244,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000006">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label>protein synthesis inhibition</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating inhibition of protein synthesis.</pathgo:IAO_0000115>
+        <rdfs:label>mediates protein synthesis inhibition</rdfs:label>
     </owl:Class>
     
 
@@ -210,6 +257,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000003"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of neurotransmitter release</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example agatoxin, omega conotoxin, dendrotoxin</skos:editorialNote>
+        <skos:editorialNote>inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved</skos:editorialNote>
     </owl:Class>
     
 
@@ -217,18 +265,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000008 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000008">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000015"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">second messenger molecule modulator</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000009 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000009">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067"/>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BVF:0000006</oboInOwl:hasDbXref>
-        <rdfs:label>siderophore</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by inhibiting the synthesis of DNA.</pathgo:IAO_0000115>
+        <rdfs:label>DNA synthesis inhibition factor</rdfs:label>
     </owl:Class>
     
 
@@ -236,8 +275,8 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000010 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000010">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000016"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-specific T-cell activation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000031"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates non-specific T-cell activation</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example SEB (superantigens)</skos:editorialNote>
     </owl:Class>
     
@@ -248,6 +287,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040"/>
         <rdfs:label>post-synaptic membrane potential modulator</rdfs:label>
+        <skos:editorialNote>evaluate placement; inconsistent as child class to membrane potential disruption factor</skos:editorialNote>
     </owl:Class>
     
 
@@ -256,26 +296,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates cellular transport disruption by blocking exocytosis.</pathgo:IAO_0000115>
         <rdfs:label>determinant of exocytosis blockade</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000013 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000013">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>enterotoxin</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000014 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000014">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves delivery of factors into target cells</pathgo:IAO_0000115>
-        <rdfs:label>intracellular delivery</rdfs:label>
     </owl:Class>
     
 
@@ -283,8 +305,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000015">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cellular signaling regulation factor</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by disrupting host cellular signaling processes.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cellular signaling disruption factor</rdfs:label>
+        <skos:editorialNote>refine/build out subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -292,8 +316,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000016 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000016">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">immune modulation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by modulating host immune system components and processes.  Immune responses can be at the cellular level, or the organismal level.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">modulates host immune function</rdfs:label>
     </owl:Class>
     
 
@@ -301,8 +326,12 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000017 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000017">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>cardiotoxin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000191"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts ion transport by inhibiting acid-sensing ion channels. Acid-sensing ion channel 1a (ASIC1a) is the primary acid sensor in mammalian brain.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acid-sensing ion channel inhibitor</rdfs:label>
+        <skos:editorialNote>&quot;Acid-sensing ion channel 1a (ASIC1a) is the primary acid sensor in mammalian brain.&quot;  evaluate information
+
+concept possibly covered by GO</skos:editorialNote>
     </owl:Class>
     
 
@@ -311,8 +340,10 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000018">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000047"/>
-        <rdfs:label>synaptic vesicle release blockade</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that prevents exocytosis by blocking release of synaptic vesicles.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts synaptic vesicle release</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">examples tetanus bot toxin</skos:editorialNote>
+        <skos:editorialNote>inconsistent as a subclass as this is a specific case of disrupting exocytosis and not a mechanism by which exocytosis is disrupted</skos:editorialNote>
     </owl:Class>
     
 
@@ -320,17 +351,8 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process or component of toxicity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000020 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000020">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>myotoxin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type I secretion</rdfs:label>
     </owl:Class>
     
 
@@ -341,6 +363,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000003"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of post-synaptic membrane potential</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example alpha bungarotoxin; cardiac glycosides (post syn calcium in muscle)</skos:editorialNote>
+        <skos:editorialNote>inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved</skos:editorialNote>
     </owl:Class>
     
 
@@ -349,6 +372,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000022">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040"/>
+        <pathgo:IAO_0000115>A gene product that modulates the propagation of action potentials by disrupting membrane potentials.</pathgo:IAO_0000115>
         <rdfs:label>action potential propagation modulator</rdfs:label>
     </owl:Class>
     
@@ -360,6 +384,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000003"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of action potential propagation</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example tetrodotoxin, scorpion toxins</skos:editorialNote>
+        <skos:editorialNote>inconsistent as a subclass as this is a consequence of ion channel activity modulation; should be moved</skos:editorialNote>
     </owl:Class>
     
 
@@ -368,8 +393,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000024">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000012"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that prevents exocytosis by blocking release of synaptic vesicles.</pathgo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">synaptic vesicle release blocker</rdfs:label>
-        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example tetanus toxin (synaptobrevin cleavage), bot toxin (snare cleavage)</skos:editorialNote>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example tetanus toxin (synaptobrevin cleavage; molecular target synaptobrevin), bot toxin (snare cleavage; molecular target snare protein)</skos:editorialNote>
     </owl:Class>
     
 
@@ -378,26 +404,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000025">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000006"/>
-        <rdfs:label>elongation factor 2 inactivation</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that mediates protein synthesis inhibition by inactivation of elongation factor 2.</pathgo:IAO_0000115>
+        <rdfs:label>mediates elongation factor 2 inactivation</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">examples diphtheria toxin and Pseudomonas exotoxin A</skos:editorialNote>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000026 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000026">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>hepatotoxin</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000027 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000027">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040"/>
-        <rdfs:label>neurotransmitter release modulator</rdfs:label>
     </owl:Class>
     
 
@@ -406,7 +415,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000166"/>
-        <rdfs:label>disruption of actin cytoskeleton</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular structure by altering maintenance of cytoskeleton.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts cytoskeleton maintenance</rdfs:label>
     </owl:Class>
     
 
@@ -415,7 +425,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000029">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000166"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">membrane damage</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular structure by damaging the cell membrane.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates membrane damage</rdfs:label>
+        <skos:editorialNote>consider vacuolization</skos:editorialNote>
     </owl:Class>
     
 
@@ -424,7 +436,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000030">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000006"/>
-        <rdfs:label>ribosome inactivation</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that mediates protein synthesis inhibition by ribosome inactivation.</pathgo:IAO_0000115>
+        <rdfs:label>mediates ribosome inactivation</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">examples ricin</skos:editorialNote>
     </owl:Class>
     
@@ -433,8 +446,11 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000031 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000029"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phospholipid cleavage</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000016"/>
+        <rdfs:label>mediates non-productive immune system activation</rdfs:label>
+        <skos:editorialNote>evaluate class name and intent; determine how to capture superantigens
+
+Evaluate changing label to &quot;mediates immune system activation&quot;</skos:editorialNote>
     </owl:Class>
     
 
@@ -443,6 +459,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000032">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000043"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates membrane damage by formation of pores.</pathgo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of pore formation</rdfs:label>
     </owl:Class>
     
@@ -452,7 +469,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000033">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000029"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pore formation</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that mediates membrane damage by formation of pores.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates pore formation</rdfs:label>
     </owl:Class>
     
 
@@ -460,8 +478,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000034 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000034">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of protein synthesis inhibition</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by inhibiting protein synthesis.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein synthesis inhibition factor</rdfs:label>
     </owl:Class>
     
 
@@ -469,26 +488,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000035 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000035">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">immune modulator</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019"/>
-        <rdfs:label>mechanism of toxicity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000037 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000037">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>dermatoxin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081"/>
+        <rdfs:label>non-productive immune system activation factor</rdfs:label>
+        <skos:editorialNote>evaluate class name and intent; determine how to capture superantigens</skos:editorialNote>
     </owl:Class>
     
 
@@ -497,8 +499,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000038">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000147"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of attachment to a surface</pathgo:IAO_0000115>
-        <rdfs:label>adherence</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that enables adhesion and colonization by mediating attachment to other cells or to surfaces.</pathgo:IAO_0000115>
+        <rdfs:label>mediates adhesion</rdfs:label>
     </owl:Class>
     
 
@@ -507,6 +509,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000034"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that inhibits protein synthesis by ribosome inactivation.</pathgo:IAO_0000115>
         <rdfs:label>ribosome inactivator</rdfs:label>
         <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example ricin</skos:editorialNote>
     </owl:Class>
@@ -516,26 +519,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ion gradient modulator</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000041 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000041">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000019"/>
-        <rdfs:label>toxin category</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000042 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000042">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>nephrotoxin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by disrupting membrane potential.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">membrane potential disruption factor</rdfs:label>
     </owl:Class>
     
 
@@ -544,34 +530,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000182"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular structure by damaging the cell membrane.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lysin</oboInOwl:hasRelatedSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of membrane damage</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000044 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000044">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000166"/>
-        <rdfs:label>vacuolization</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000045 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000045">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>pulmonary toxin</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000041"/>
-        <rdfs:label>organ system category</rdfs:label>
     </owl:Class>
     
 
@@ -580,16 +541,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000047">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000167"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exocytosis blockade</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000048 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000048">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000046"/>
-        <rdfs:label>neurotoxin</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular transport by blocking exocytosis.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disrupts exocytosis</rdfs:label>
     </owl:Class>
     
 
@@ -598,17 +551,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>type V secretion system</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000050 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000123"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Type of intracellular motility that uses actin filaments</pathgo:IAO_0000115>
-        <rdfs:label>actin-based intracellular motility</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type V secretion</rdfs:label>
     </owl:Class>
     
 
@@ -616,8 +559,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000051 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000051">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000077"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000198"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates cell surface binding through integrins.</pathgo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">integrin binding protein</rdfs:label>
+        <skos:editorialNote>integrin α2β1 binding protein and integrin αMβ2 binding protein are examples that may be too granular to include</skos:editorialNote>
     </owl:Class>
     
 
@@ -631,20 +576,11 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000053 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000053">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000195"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VEGF secretion</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000054">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111"/>
-        <rdfs:label>virulence factor synthesis</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">synthesis of pathogenicity determinants</rdfs:label>
     </owl:Class>
     
 
@@ -652,27 +588,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000055">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000118"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of invasion that involves cleaving membrane phospholipids</pathgo:IAO_0000115>
-        <rdfs:label>cleavage of membrane phospholipids</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000056 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000056">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label>protease</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000057 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000057">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157"/>
-        <rdfs:label>lysin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000029"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates membrane damage by cleavage of membrane phospholipids.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates membrane phospholipid cleavage</rdfs:label>
+        <skos:editorialNote>evaluate for placement in invasion and dissemination</skos:editorialNote>
     </owl:Class>
     
 
@@ -681,17 +600,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves acquisition of iron</pathgo:IAO_0000115>
-        <rdfs:label>iron uptake</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000059 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000059">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label>outer membrane protein</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of nutrient avialability or uptake that involves acquisition of iron.</pathgo:IAO_0000115>
+        <rdfs:label>mediates iron uptake</rdfs:label>
     </owl:Class>
     
 
@@ -700,17 +610,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000075"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves decreasing or abolishing the production of immune system cytokines</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of innate immune system subversion that involves decreasing or abolishing the production of immune system cytokines.</pathgo:IAO_0000115>
         <rdfs:label>cytokine response suppression</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000061 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000061">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cyclin-dependent kinase 1 inactivator</rdfs:label>
+        <skos:editorialNote>redundant</skos:editorialNote>
     </owl:Class>
     
 
@@ -719,9 +621,11 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000147"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of colonization that involves synthesis of extracellular polymeric substances in a film</pathgo:IAO_0000115>
-        <rdfs:label>biofilm formation</rdfs:label>
-        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Process whereby microorganisms irreversibly attach to and grow on a surface and produce extracellular polymers that facilitate attachment and matrix formation, resulting in an alteration in the phenotype of the organisms with respect to growth rate and gene transcription. (Donlan, Rodney M. &quot;Biofilm formation: a clinically relevant microbiological process.&quot; Clinical Infectious Diseases 33.8 (2001): 1387-1392.)</skos:editorialNote>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that enables adhesion and colonization by promoting synthesis of extracellular polymeric substances to form a biofilm.</pathgo:IAO_0000115>
+        <rdfs:label>mediates biofilm formation</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Process whereby microorganisms irreversibly attach to and grow on a surface and produce extracellular polymers that facilitate attachment and matrix formation, resulting in an alteration in the phenotype of the organisms with respect to growth rate and gene transcription. (Donlan, Rodney M. &quot;Biofilm formation: a clinically relevant microbiological process.&quot; Clinical Infectious Diseases 33.8 (2001): 1387-1392.)
+
+Mechanism of colonization that involves synthesis of extracellular polymeric substances in a film.</skos:editorialNote>
     </owl:Class>
     
 
@@ -729,8 +633,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000063 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000063">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:label>lysis of host cells</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting the cell cycle of a host cell.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disrupts cell cycle</rdfs:label>
+        <skos:editorialNote>Concept covered by GO; GO:0051726; elaborate subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -738,8 +644,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000064 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000064">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
-        <rdfs:label>adenylate cyclase</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000015"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts host cellular signaling by modulating levels of second messenger molecules.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">second messenger disruption factor</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cyclin-dependent kinase 1 inactivator; calcium- and calmodulin-dependent adenylate cyclase</skos:editorialNote>
     </owl:Class>
     
 
@@ -757,8 +665,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000066">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000058"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of iron uptake that involves taking iron from a target cell</pathgo:IAO_0000115>
-        <rdfs:label>iron acquisition from host</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of iron uptake that involves taking iron from a target cell.</pathgo:IAO_0000115>
+        <rdfs:label>mediates iron acquisition from host</rdfs:label>
     </owl:Class>
     
 
@@ -766,17 +674,14 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label>nutrient uptake factor</rdfs:label>
-    </owl:Class>
-    
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000105"/>
+        <pathgo:IAO_0000115>A gene product that promotes proliferation and survival by contributing to the availability and/or uptake of nutrients from host cells or the environment.</pathgo:IAO_0000115>
+        <rdfs:label>nutrient availability or uptake factor</rdfs:label>
+        <skos:editorialNote>examples may include: gelatinase, mucinase, sialidase, hyaluronidase - enzymes that are also associated with destruction of extracellular matrix, mucus, etc. to promote invasion and spread in the host 
 
+siderophore-chelate and sequester iron from host
 
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000068 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000068">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label>coagulation cascade modulator</rdfs:label>
+elaborate subclasses; align with mechanism branch</skos:editorialNote>
     </owl:Class>
     
 
@@ -785,16 +690,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000069">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000077"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates adhesion through collagen binding.</pathgo:IAO_0000115>
         <rdfs:label>collagen binding protein</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000070 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000070">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120"/>
-        <rdfs:label>fimbriae protein</rdfs:label>
     </owl:Class>
     
 
@@ -811,9 +708,12 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000072 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000072">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000038"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of adherence that involves binding to a sugar-modified surface protein on a target cell</pathgo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000211"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates cell surface binding through glycoproteins.</pathgo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glycoprotein binding</rdfs:label>
+        <skos:editorialNote>evaluate for organizational consistency
+
+A mechanism of cell surface binding that involves binding to a sugar-modified surface protein on a target cell.</skos:editorialNote>
     </owl:Class>
     
 
@@ -822,10 +722,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any molecule produced by bacteria, viruses, fungi or protozoa enabling them to achieve colonization of a niche in the host, inhibit or evade the host&apos;s immune response, enter and exit cells, or obtain nutrition from the host.</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A molecule produced by microbes (bacteria, viruses, fungi or protozoa) that enables them to achieve colonization of a host, inhibit or evade the host&apos;s immune response, enter and exit cells, or obtain nutrition from the host.</pathgo:IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:72316</oboInOwl:hasDbXref>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wikipedia: Virulence factors are molecules produced by bacteria, viruses, fungi, and protozoa that add to their effectiveness and enable them to achieve the following: colonization of a niche in the host (this includes attachment to cells) immunoevasion, evasion of the host&apos;s immune response immunosuppression, inhibition of the host&apos;s immune response entry into and exit out of cells (if the pathogen is an intracellular one) obtain nutrition from the host Specific pathogens possess a wide array of virulence factors. Some are chromosomally encoded and intrinsic to the bacteria (e.g. capsules and endotoxin), whereas others are obtained from mobile genetic elements like plasmids and bacteriophages (e.g. some exotoxins). Virulence factors encoded on mobile genetic elements spread through horizontal gene transfer, and can convert harmless bacteria into dangerous pathogens. Bacteria like Escherichia coli O157:H7 gain the majority of their virulence from mobile genetic elements. Gram-negative bacteria secrete a variety of virulence factors at host-pathogen interface, via membrane vesicle trafficking as bacterial outer membrane vesicles for invasion, nutrition and other cell-cell communications. It has been found that many pathogens have converged on similar virulence factors to battle against eukaryotic host defenses. These obtained bacterial virulence factors have two different routes used to help them survive and grow: The factors are used to assist and promote colonization of the host. These factors include adhesins, invasins, and antiphagocytic factors. The factors, including toxins, hemolysins, and proteases, bring damage to the host.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of virulence</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of pathogenicity</rdfs:label>
     </owl:Class>
     
 
@@ -834,8 +733,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000074">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000150"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves stimulation of host blood vessel generation, or angiogenesis</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">induction of angiogenesis</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that promotes proliferation and survival by stimulation of host blood vessel generation, or angiogenesis.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates induction of angiogenesis</rdfs:label>
     </owl:Class>
     
 
@@ -844,17 +743,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000075">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves producing factors that hide a pathogen from the innate immune system, or subvert the ability of the innate immune system to respond to the pathogen.</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of immune evasion and subversion that involves producing factors that hide a pathogen from the innate immune system, or subvert the ability of the innate immune system to respond to the pathogen.</pathgo:IAO_0000115>
         <rdfs:label>innate immune system subversion</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000076 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000076">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081"/>
-        <rdfs:label>hyaluronidase</rdfs:label>
+        <skos:editorialNote>not consistent as a subclass-evaluate for removal; all subclasses to this class are represented as subclasses of &apos;mediates immune evasion and subversion&apos;</skos:editorialNote>
     </owl:Class>
     
 
@@ -863,17 +754,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000077">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extracellular matrix binding protein</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000078 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000078">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000014"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of Intracellular delivery where the factors being delivered are proteins</pathgo:IAO_0000115>
-        <rdfs:label>intracellular delivery of effector proteins</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates adhesion by enabling binding to extracellular matrix components such as collagen and fibronectin.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extracellular matrix binding factor</rdfs:label>
+        <skos:editorialNote>Collagen binding protein and fibronectin binding protein are examples.  Including these as subclasses may be too granular.</skos:editorialNote>
     </owl:Class>
     
 
@@ -881,8 +764,11 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000079 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000079">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">deoxyribonuclease (DNase)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by cleaving DNA.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">deoxyribonuclease (DNAse)</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA cleavage factor</rdfs:label>
+        <skos:editorialNote>Target is the macromolecule and not process so this term doesn&apos;t fit definition of parent class</skos:editorialNote>
     </owl:Class>
     
 
@@ -891,8 +777,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000080">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that blocks immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells</pathgo:IAO_0000115>
-        <rdfs:label>dendritic cell maturation inhibitor</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates immune evasion and subversion by blocking immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells.</pathgo:IAO_0000115>
+        <rdfs:label>inhibits dendritic cell maturation</rdfs:label>
     </owl:Class>
     
 
@@ -901,10 +787,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Molecules associated with the penetration of pathogens into host cells</pathgo:IAO_0000115>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BVF:0000003</oboInOwl:hasDbXref>
-        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">invasin</oboInOwl:hasRelatedSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">invasion factor</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by modulating host immune system components and processes.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">host immune function modulation factor</rdfs:label>
     </owl:Class>
     
 
@@ -913,8 +797,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000082">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves peptide and protein degradation for the purpose of nutrient acquisition</pathgo:IAO_0000115>
-        <rdfs:label>peptide and protein degradation</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of nutrient availability or uptake that involves peptide and protein degradation.</pathgo:IAO_0000115>
+        <rdfs:label>mediates peptide and protein degradation</rdfs:label>
+        <skos:editorialNote>overlaps with extracellular matrix destruction under invasion and dissemination</skos:editorialNote>
     </owl:Class>
     
 
@@ -923,7 +808,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000083">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111"/>
-        <rdfs:label>virulence factor target</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathogenicity target</rdfs:label>
     </owl:Class>
     
 
@@ -932,8 +817,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000084">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that prevents immune system cells from growing via cell division</pathgo:IAO_0000115>
-        <rdfs:label>inhibition of lymphocyte proliferation</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates immune evasion and subversion by preventing lymphocytes from growing via cell division.</pathgo:IAO_0000115>
+        <rdfs:label>inhibits lymphocyte proliferation</rdfs:label>
     </owl:Class>
     
 
@@ -941,9 +826,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves producing factors that hide a pathogen from the immune system, or that actively counter or subvert host cell immunity</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">immune evasion and subversion</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000016"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by modulating the availability or function of immune system components to evade or subvert host immune functions.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates immune evasion and subversion</rdfs:label>
     </owl:Class>
     
 
@@ -952,7 +837,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000086">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000112"/>
-        <rdfs:label>autoinducer synthase</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that contributes to quorum sensing by promoting production of autoinducer molecules.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">quorum sensing autoinducer production factor</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">autoinducer synthase</skos:editorialNote>
     </owl:Class>
     
 
@@ -969,9 +856,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000088 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000088">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that alters host cell signaling for pathogenic purposes, whether adherence and colonization, proliferation and survival, invasion, or some other purpose.</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of host cell signaling</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000160"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular adhesion by modification of tight junction formation.</pathgo:IAO_0000115>
+        <rdfs:label>tight junction modifier</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example: Clostridium perfringens type A toxin (targets claudins)  more info: https://doi.org/10.1016/j.bbamem.2008.10.028; https://www.ncbi.nlm.nih.gov/pubmed/11595640</skos:editorialNote>
     </owl:Class>
     
 
@@ -979,8 +867,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000089 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000089">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000127"/>
-        <rdfs:label>disruption of mitochondrial membrane potential</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating the alteration of mitochondrial membrane potential.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts mitochondrial membrane potential</rdfs:label>
     </owl:Class>
     
 
@@ -988,26 +877,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by modulating the availability or function of immune system components to evade or subvert host immune functions.</pathgo:IAO_0000115>
         <rdfs:label>immune evasion and subversion factor</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000091 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000091">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000064"/>
-        <rdfs:label>calcium- and calmodulin-dependent adenylate cyclase</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000092 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000092">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000134"/>
-        <rdfs:label>type IV pili</rdfs:label>
     </owl:Class>
     
 
@@ -1015,8 +887,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000093 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000093">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000068"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000194"/>
         <rdfs:label>coagulation factor V protease</rdfs:label>
+        <skos:editorialNote>This is an example.  It should be moved as it does not directly impact platelet aggregation, rather it t inhibits coagulation cascade to disrupt coagulation.</skos:editorialNote>
     </owl:Class>
     
 
@@ -1024,18 +897,8 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000094">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000056"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000015"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitogen-activated protein kinase kinases (MAPKKs) protease</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000095 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000095">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BVF:0000004</oboInOwl:hasDbXref>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surface components</rdfs:label>
     </owl:Class>
     
 
@@ -1043,28 +906,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000096 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000096">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000118"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of invasion that involves degradation of polysaccharides</pathgo:IAO_0000115>
-        <rdfs:label>degradation of polysaccharide</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000097 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000097">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism for evading the immune system by varying the sequence or structure of pathogen components targeted by immune cells</pathgo:IAO_0000115>
-        <rdfs:label>evasion of immune effectors by antigenic variation</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000098 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000098">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000116"/>
-        <rdfs:label>small GTPase activating protein</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000029"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates membrane damage by degradation of polysaccharides.</pathgo:IAO_0000115>
+        <rdfs:label>mediates polysaccharide degradation</rdfs:label>
+        <skos:editorialNote>evaluate for placement in invasion and dissemination</skos:editorialNote>
     </owl:Class>
     
 
@@ -1073,8 +918,10 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000038"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of adherence in which attachment occurs to components of the extracellular matrix as opposed to the target cell directly</pathgo:IAO_0000115>
-        <rdfs:label>binding to extracellular matrix</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that enables adhesion by mediating binding to extracellular matrix components such as collagen and fibronectin.</pathgo:IAO_0000115>
+        <rdfs:label>mediates extracellular matrix binding</rdfs:label>
+        <skos:editorialNote>Mechanism of adherence in which attachment occurs to components of the extracellular matrix as opposed to the target cell directly;
+elaborate subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -1082,9 +929,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000100 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000100">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000075"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves avoiding or countering the effects of the complement system, a component of the innate immune system</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">resistance to complement-mediated killing</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates immune evasion and subversion by countering the effects of the complement system, a component of the innate immune system.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates resistance to complement system</rdfs:label>
+        <skos:editorialNote>resistance to complement-mediated killing</skos:editorialNote>
     </owl:Class>
     
 
@@ -1094,6 +942,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
         <rdfs:label>lymphocyte proliferation inhibition factor</rdfs:label>
+        <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates immune evasion and subversion by preventing lymphocytes from growing via cell division.</skos:definition>
     </owl:Class>
     
 
@@ -1102,7 +951,21 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secretion system factor</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by contributing to secretion of protein effectors from the bacterial cell into the extracellular environment or directly into the host cell.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of protein effector secretion</rdfs:label>
+        <skos:editorialNote>The secretion pathways are typically described as &quot;types&quot; based on components/structures involved corresponding to variations on a few general strategies involving transport across inner membrane, transport across inner membrane followed by transport across outer membrane (two-step), transport across both membranes. Several types can also transport proteins directly across the host cell membrane to deliver effectors directly into cells
+
+Type I- one step to extracellular
+Type II- two step, first step is independent transport into periplasm
+Type III- spans both membranes, injectosome into host cell
+Type IV- spans both membranes, release of effectors into other cell (conjugation)
+Type V-autotransporter in OM, first step is independent transport into periplasm
+Type VI- spans both membranes, release into other cell
+
+https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4804464/
+https://www.sciencedirect.com/science/article/pii/S0167488904000783
+
+Evaluate subclass naming/organization</skos:editorialNote>
     </owl:Class>
     
 
@@ -1111,7 +974,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000103">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
-        <rdfs:label>Toll-like receptor adaptor protein degradation activator</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">toll-like receptor signaling disruption factor</rdfs:label>
+        <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates immune evasion and subversion by disrupting toll-like receptor signaling.</skos:definition>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adaptor protein degradation activator; research and add others</skos:editorialNote>
     </owl:Class>
     
 
@@ -1120,8 +985,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves preventing antibacterial peptides from binding to their targets</pathgo:IAO_0000115>
-        <rdfs:label>obstruction of antibacterial peptide binding</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates immune evasion and subversion by preventing antibacterial peptides from binding to their targets.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts antimicrobial peptide binding</rdfs:label>
     </owl:Class>
     
 
@@ -1130,26 +995,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by enabling proliferation and/or survival of a pathogen, especially when environmental conditions are unfavorable, not related to adherence and colonization.</pathgo:IAO_0000115>
         <rdfs:label>proliferation and survival factor</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000106 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000106">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that allows organisms to move independently, using metabolic energy.  Types of bacterial movement include swimming, swarming, gliding, twitching, and sliding.</pathgo:IAO_0000115>
-        <rdfs:label>motility</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000107 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000107">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120"/>
-        <rdfs:label>monocyte/macrophage adherence protein</rdfs:label>
+        <skos:editorialNote>evaluate placement and provide examples</skos:editorialNote>
     </owl:Class>
     
 
@@ -1157,17 +1005,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000108 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000108">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:label>inhibition of actin polymerization</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000109 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000109">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067"/>
-        <rdfs:label>sialidase</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cytoskeleton maintenance by mediating inhibition of actin polymerization.</pathgo:IAO_0000115>
+        <rdfs:label>mediates actin polymerization inhibition</rdfs:label>
     </owl:Class>
     
 
@@ -1176,8 +1016,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that leads to transport of virulence determinants from inside a pathogen to the extracellular space</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secretion of virulence determinants</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by contributing to secretion of protein effectors from the bacterial cell into the extracellular environment or directly into the host cell.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates secretion of protein effectors</rdfs:label>
+        <skos:editorialNote>elaborate subclasses and align with determinant branch</skos:editorialNote>
     </owl:Class>
     
 
@@ -1186,7 +1027,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process or component of virulence</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathogenicity is the ability of microbes to have damaging effects on cells.  A process or component of pathogenicity is an expression that describes how a pathogen exerts its effect on host cells, or through what determinant that effect is achieved.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process or component of pathogenicity</rdfs:label>
     </owl:Class>
     
 
@@ -1195,7 +1037,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000112">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000119"/>
-        <rdfs:label>quorom sensing system factor</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that promotes biofilm formation by contributing to quorum sensing.</pathgo:IAO_0000115>
+        <rdfs:label>quorum sensing system factor</rdfs:label>
     </owl:Class>
     
 
@@ -1203,9 +1046,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that facilitates the uptake of nutrients from host cells or the environment</pathgo:IAO_0000115>
-        <rdfs:label>nutrient uptake</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000150"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that promotes proliferation and survival by contributing to the availability and/or uptake of nutrients from host cells or the environment.</pathgo:IAO_0000115>
+        <rdfs:label>mediates nutrient availability or uptake</rdfs:label>
+        <skos:editorialNote>evaluate and modify subclasses to achieve consistent structure; align to determinant branch</skos:editorialNote>
     </owl:Class>
     
 
@@ -1214,7 +1058,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000111"/>
-        <rdfs:label>mechanism of virulence</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A process that pathogens perform to have damaging effects on cells, and that specifically describes how that effect is exerted.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mechanism of pathogenicity</rdfs:label>
     </owl:Class>
     
 
@@ -1231,8 +1076,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000116 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000116">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label>regulator of cell signaling</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by modulating the activity of nitric oxide synthase.</pathgo:IAO_0000115>
+        <rdfs:label>regulator of nitric oxide synthase</rdfs:label>
+        <skos:editorialNote>inappropriate placement; Overlaps with GO (molecular function and regulation of activity terms); evaluate for removal</skos:editorialNote>
     </owl:Class>
     
 
@@ -1246,20 +1093,11 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000118 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000118">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that allows pathogens to spread within host cells or throughout organisms, and that is distinct from adherence and colonization</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">invasion</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000119 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000151"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates adherence and colonization by promoting synthesis of extracellular polymeric substances to form a biofilm.</pathgo:IAO_0000115>
         <rdfs:label>biofilm formation factor</rdfs:label>
     </owl:Class>
     
@@ -1269,18 +1107,12 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000151"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell-surface components or appendages of bacteria that facilitate adhesion or adherence to other cells or to surfaces, usually the host they are infecting or living in</pathgo:IAO_0000115>
-        <rdfs:label>adhesin</rdfs:label>
-    </owl:Class>
-    
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that facilitates adhesion and colonization by enabling attachment to other cells or to surfaces, usually the host they are infecting or living in.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adhesin</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adhesion factor</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition needs to be rewritten
 
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that results in death of a host orgnanism</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cell killing</rdfs:label>
+encodes cell-surface or appendage components of bacteria</skos:editorialNote>
     </owl:Class>
     
 
@@ -1288,19 +1120,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000122 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000122">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leads to high levels of nitric oxide radicals.  Nitric oxide destroys iron-dependent enzymes, eventually inhibiting mitochondrial function and DNA synthesis in nearby host cells.</pathgo:IAO_0000115>
-        <rdfs:label>activator of host cell nitric oxide synthase</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000123 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000123">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000106"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Type of motility that occurs inside cells</pathgo:IAO_0000115>
-        <rdfs:label>intracellular motility</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000116"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that activates nitric oxide synthase enzyme  leading to high levels of nitric oxide radicals.  Nitric oxide radicals destroy iron-dependent enzymes, eventually inhibiting mitochondrial function and DNA synthesis in nearby host cells.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nitric oxide synthase activator</rdfs:label>
+        <skos:editorialNote>Overlaps with GO (molecular function and regulation of activity terms)</skos:editorialNote>
     </owl:Class>
     
 
@@ -1309,8 +1132,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000124">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000058"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of iron uptake that involves using iron in the environment</pathgo:IAO_0000115>
-        <rdfs:label>iron acquisition from environment</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of iron uptake that involves using iron in the environment.</pathgo:IAO_0000115>
+        <rdfs:label>mediates iron acquisition from environment</rdfs:label>
     </owl:Class>
     
 
@@ -1319,35 +1142,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000125">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000150"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that allows that pathogens to survive periods without water, or drought-like conditions</pathgo:IAO_0000115>
-        <rdfs:label>desiccation resistance</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000126 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000126">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000057"/>
-        <rdfs:label>hemolysin</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000127 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000127">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
-        <rdfs:label>inhibition of mitochondrial function</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000128 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000128">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000095"/>
-        <rdfs:label>poly-beta-1-6-N-acetylglucosamine (PNAG)</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that promotes proliferation and survival by enabling pathogens to survive periods without water, or drought-like conditions.</pathgo:IAO_0000115>
+        <rdfs:label>mediates desiccation resistance</rdfs:label>
     </owl:Class>
     
 
@@ -1356,17 +1152,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000129">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000075"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that prevents phagocytosis of pathogens by immune system cells like macrophages</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of innate immune system subversion that prevents phagocytosis of pathogens by immune system cells like macrophages.</pathgo:IAO_0000115>
         <rdfs:label>antiphagocytosis</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000130 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000130">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067"/>
-        <rdfs:label>mucinase</rdfs:label>
+        <skos:editorialNote>redundant</skos:editorialNote>
     </owl:Class>
     
 
@@ -1374,7 +1162,7 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000131 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000131">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000088"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tight-junction-associated protein occludin redistribution factor</rdfs:label>
     </owl:Class>
     
@@ -1383,8 +1171,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000132 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000132">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:label>inhibition of DNA synthesis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating inhibition of DNA synthesis.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates DNA synthesis inhibition</rdfs:label>
     </owl:Class>
     
 
@@ -1393,6 +1182,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000133">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000077"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates adhesion through fibronectin binding.</pathgo:IAO_0000115>
         <rdfs:label>fibronectin binding protein</rdfs:label>
     </owl:Class>
     
@@ -1402,7 +1192,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000134">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>type IV secretion system</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type IV secretion</rdfs:label>
     </owl:Class>
     
 
@@ -1410,46 +1200,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000135 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000135">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:label>deoxyribonuclease activity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000136 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000136">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000051"/>
-        <rdfs:label>integrin αMβ2 binding protein</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000137 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000137">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>RND-type efflux system</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000138 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000138">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000169"/>
-        <rdfs:label>induction of apoptosis</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000139 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000139">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000106"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Type of motility that occurs through an organism</pathgo:IAO_0000115>
-        <rdfs:label>systemic motility</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating cleavage of DNA.</pathgo:IAO_0000115>
+        <rdfs:label>mediates DNA cleavage</rdfs:label>
     </owl:Class>
     
 
@@ -1458,7 +1211,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000140">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>type II secretion system</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type II secretion</rdfs:label>
     </owl:Class>
     
 
@@ -1467,7 +1220,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000141">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>type III secretion system</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type III secretion</rdfs:label>
     </owl:Class>
     
 
@@ -1476,18 +1229,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000142">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves taking cholesterol from the membranes of target cells</pathgo:IAO_0000115>
-        <rdfs:label>acquisition of cholesterol from membrane</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000143 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000143">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000118"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism of invasion that involves disrupting the barrier function of epithelial cell layers</pathgo:IAO_0000115>
-        <rdfs:label>disruption of epithelial cell barrier function</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates nutrient availability or uptake by taking cholesterol from the membranes of target cells.</pathgo:IAO_0000115>
+        <rdfs:label>mediates acquisition of cholesterol from membrane</rdfs:label>
     </owl:Class>
     
 
@@ -1495,28 +1238,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000144 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000144">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by disrupting the membrane potential of the mitochondria.</pathgo:IAO_0000115>
         <rdfs:label>mitochondrial membrane potential disruption factor</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000145 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000145">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000095"/>
-        <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid-containing polysaccharides which are endotoxins and important group-specific antigens. They are often derived from the cell wall of gram-negative bacteria and induce immunoglobulin secretion. The lipopolysaccharide molecule consists of three parts: LIPID A, core polysaccharide, and O-specific chains ( O ANTIGENS). When derived from Escherichia coli, lipopolysaccharides serve as polyclonal B-cell mitogens commonly used in laboratory immunology. (From Dorland, 28th ed).</dc:description>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BVF:0000028</oboInOwl:hasDbXref>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipopolysaccharide (LPS)</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000146 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000146">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000081"/>
-        <rdfs:label>sialyl Lewis x binding protein</rdfs:label>
     </owl:Class>
     
 
@@ -1525,17 +1249,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000147">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that enables viruses and bacteria to attach to host cells and establish growth</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adherence and colonization</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000148 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000148">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000051"/>
-        <rdfs:label>integrin α2β1 binding protein</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by enabling pathogens to attach to host cells and establish growth.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates adherence and colonization</rdfs:label>
+        <skos:editorialNote>&quot;enables adherence and colonization&quot;</skos:editorialNote>
     </owl:Class>
     
 
@@ -1544,8 +1260,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000149">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves polysaccharide degradation for the purpose of nutrient acquisition</pathgo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polysaccharide degradation</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of nutrient availability or uptake that involves polysaccharide degradation.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mediates polysaccharide degradation</rdfs:label>
+        <skos:editorialNote>this is not consistent with &quot;mediates uptake&quot;</skos:editorialNote>
     </owl:Class>
     
 
@@ -1554,8 +1271,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000150">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that allows pathogens to grow and multiply, distinct from adherence and colonization and/or invasion</pathgo:IAO_0000115>
-        <rdfs:label>proliferation and survival</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by allowing pathogens to grow and multiply, especially when environmental conditions are unfavorable, distinct from adherence and colonization.</pathgo:IAO_0000115>
+        <rdfs:label>mediates proliferation and survival</rdfs:label>
     </owl:Class>
     
 
@@ -1564,6 +1281,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000151">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by enabling pathogens to attach to host cells and establish growth.</pathgo:IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BVF:0000002</oboInOwl:hasDbXref>
         <rdfs:label>adherence and colonization factor</rdfs:label>
     </owl:Class>
@@ -1573,8 +1291,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000152 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000152">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000121"/>
-        <rdfs:label>induction of cell cycle arrest</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000063"/>
+        <rdfs:label>induces cell cycle arrest</rdfs:label>
+        <skos:editorialNote>overlap with GO:0007050</skos:editorialNote>
     </owl:Class>
     
 
@@ -1583,7 +1302,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000153">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
-        <rdfs:label>complement component 1 (C1) protease</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complement system inhibition factor</rdfs:label>
+        <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates immune evasion and subversion by inhibiting complement system function.</skos:definition>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example:component 1 (C1) protease</skos:editorialNote>
     </owl:Class>
     
 
@@ -1592,8 +1313,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000154">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000113"/>
-        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanism that involves acquisition of manganese</pathgo:IAO_0000115>
-        <rdfs:label>manganese uptake</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism of nutrient availability or uptake that involves acquisition of manganese.</pathgo:IAO_0000115>
+        <rdfs:label>mediates manganese uptake</rdfs:label>
     </owl:Class>
     
 
@@ -1611,26 +1332,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000102"/>
-        <rdfs:label>type VI secretion system</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000157">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cell killing factor</rdfs:label>
-        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Not a very information rich term!</skos:editorialNote>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000158 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000158">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000067"/>
-        <rdfs:label>gelatinase</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of type VI secretion</rdfs:label>
     </owl:Class>
     
 
@@ -1638,8 +1340,12 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of cellular adhesion</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting the adhesion of cells to other cells and/or extracellular matrix components.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disrupts cellular adhesion</rdfs:label>
+        <skos:editorialNote>evaluate for incorporation to invasion and dissemination
+
+elaborate subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -1647,8 +1353,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000160 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000160">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that confers toxicity by disrupting adhesion between cells or between cells and extracellular matrix components.</pathgo:IAO_0000115>
         <rdfs:label>cellular adhesion disruption factor</rdfs:label>
+        <skos:editorialNote>evaluate for incorporation into invasion and dissemination; elaborate subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -1656,8 +1364,11 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000161 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000161">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000162"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that compromises the intestinal mucosal barrier, permitting microbial products and/or microbes entry into the body.  The intestinal mucosal barrier consists of the intestinal epithelial layer, plus additional physical, biochemical, and immunological components.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gastrointestinal barrier disruption</oboInOwl:hasRelatedSynonym>
         <rdfs:label>mucosal barrier disruption</rdfs:label>
+        <skos:editorialNote>higher level process, not appropriate subclass; evaluate for removal or alternate placement; revise definition</skos:editorialNote>
     </owl:Class>
     
 
@@ -1666,16 +1377,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that compromises epithelial cell layers, enabling increased permeation of biomolecules and/or bacterial invasion.</pathgo:IAO_0000115>
         <rdfs:label>epithelial layer disruption</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000163 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000163">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000160"/>
-        <rdfs:label>intercellular tight junction modifier</rdfs:label>
+        <skos:editorialNote>higher level process, not appropriate subclass; evaluate for removal or alternate placement</skos:editorialNote>
     </owl:Class>
     
 
@@ -1683,8 +1387,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label>disruption of cellular metabolism</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting cellular processes involved in the synthesis or breakdown of cellular constituents or production of energy.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts cellular metabolism</rdfs:label>
     </owl:Class>
     
 
@@ -1692,8 +1397,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of cellular signaling</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting host cellular signaling processes.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disrupts host cellular signaling</rdfs:label>
+        <skos:editorialNote>refine/build out subclasses and align to determinant branch</skos:editorialNote>
     </owl:Class>
     
 
@@ -1701,8 +1408,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000166 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000166">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label>disruption of cellular structure</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting the structural integrity of a cell.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lysis of host cells</oboInOwl:hasRelatedSynonym>
+        <rdfs:label>disrupts cellular structure</rdfs:label>
     </owl:Class>
     
 
@@ -1710,8 +1419,18 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000167 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000167">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label>disruption of cellular transport</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by disrupting transport of products into, out of, and within host cells.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts cellular transport</rdfs:label>
+        <skos:editorialNote>elaborate and restructure subclasses using a consistent organizational principle
+
+example concepts to consider in determining organization:
+membrane transport
+vesicular transport
+endocytosis/exocytosis
+active/passive
+intracellular trafficking
+microtubule mediated transport</skos:editorialNote>
     </owl:Class>
     
 
@@ -1719,8 +1438,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000168 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000168">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label>enzyme inhibition</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that disrupts host cell signaling by inhibiting cellular enzymes. For inhibition of metabolic enzymes, see terms under &apos;disruption of cellular metabolism&apos;.</pathgo:IAO_0000115>
+        <rdfs:label>mediates enzyme inhibition</rdfs:label>
+        <skos:editorialNote>evaluate for placement and provide examples; disambiguate from mediates metabolic enzyme inhibition; revise definition</skos:editorialNote>
     </owl:Class>
     
 
@@ -1728,8 +1449,12 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000169 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000169">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000036"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of apoptosis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that mediates pathogenicity by impacting host cell apoptosis. Gene products produced by pathogenic microbes may induce or prevent apoptosis to enable growth inside the host.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulates apoptosis</rdfs:label>
+        <skos:editorialNote>Evaluate for placement in proliferation and survival
+
+Concept covered by GO; GO:0042981</skos:editorialNote>
     </owl:Class>
     
 
@@ -1738,7 +1463,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000170">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disruption of cellular cAMP levels</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that disrupts cellular metabolism by altering the levels of cyclic adenosine monophosphate (cyclic AMP, or cAMP) in cells.  Cyclic AMP is a second messenger molecule that regulates physiological processes in cells, through, for example, activation of intracellular signaling pathways.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disrupts cellular cAMP levels</rdfs:label>
+        <skos:editorialNote>redundant to cellular signaling &quot;second messenger disruption&quot;; should be moved; evaluate subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -1747,7 +1474,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000171">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
-        <rdfs:label>production of reactive oxygen species</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating production of reactive oxygen species.</pathgo:IAO_0000115>
+        <rdfs:label>mediates reactive oxygen species production</rdfs:label>
+        <skos:editorialNote>should be moved as it is not a logical subclass for &apos;disrupts cellular metabolism&apos;</skos:editorialNote>
     </owl:Class>
     
 
@@ -1757,6 +1486,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000172">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000171"/>
         <rdfs:label>nitric oxide radical production</rdfs:label>
+        <skos:editorialNote>evaluate placement; not appropriate subclass</skos:editorialNote>
     </owl:Class>
     
 
@@ -1765,7 +1495,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000173">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000170"/>
-        <rdfs:label>cAMP synthesis</rdfs:label>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A mechanism that disrupts cellular cAMP levels through activation of the production or repression of the breakdown of cAMP.</pathgo:IAO_0000115>
+        <rdfs:label>modulates cAMP synthesis</rdfs:label>
     </owl:Class>
     
 
@@ -1774,7 +1505,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000174">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000170"/>
-        <rdfs:label>regulation of host cell adenylate cyclases/phosphodiesterases</rdfs:label>
+        <rdfs:label>regulates host cell adenylate cyclases/phosphodiesterases</rdfs:label>
+        <skos:editorialNote>evaluate for redundancy with &quot;modulates cAMP synthesis&quot;</skos:editorialNote>
     </owl:Class>
     
 
@@ -1783,7 +1515,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000175">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165"/>
-        <rdfs:label>disruption of G-protein signaling pathways</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disprupts host cell signaling by interfering with host G-protien siignaling pathways.</pathgo:IAO_0000115>
+        <rdfs:label>disrupts G-protein signaling pathways</rdfs:label>
     </owl:Class>
     
 
@@ -1801,7 +1534,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000177">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165"/>
-        <rdfs:label>modulation of second messenger molecules</rdfs:label>
+        <pathgo:IAO_0000115>A mechanism that disrupts host cellular signaling by modulating levels of second messenger molecules.</pathgo:IAO_0000115>
+        <rdfs:label>modulates second messenger molecules</rdfs:label>
     </owl:Class>
     
 
@@ -1818,17 +1552,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that confers pathogenicity by disrupting cellular processes involved in the synthesis or breakdown of cellular constituents or production of energy.</pathgo:IAO_0000115>
         <rdfs:label>cellular metabolism disruption factor</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000180 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000180">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
-        <rdfs:label>nitric oxide synthase inhibitor</rdfs:label>
     </owl:Class>
     
 
@@ -1845,7 +1571,8 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000182 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000182">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by disrupting structural components of cells.</pathgo:IAO_0000115>
         <rdfs:label>cellular structure disruption factor</rdfs:label>
     </owl:Class>
     
@@ -1855,6 +1582,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000182"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular structure by disrupting components of the cytoskeleton.</pathgo:IAO_0000115>
         <rdfs:label>cytoskeleton disruption factor</rdfs:label>
     </owl:Class>
     
@@ -1864,6 +1592,13 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000184">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000243"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000217"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cytoskeleton structure by crosslinking actin.</pathgo:IAO_0000115>
         <rdfs:label>actin crosslinker</rdfs:label>
     </owl:Class>
     
@@ -1873,6 +1608,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000185">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cytoskeleton structure by depolymerizing actin.</pathgo:IAO_0000115>
         <rdfs:label>actin depolymerization factor</rdfs:label>
     </owl:Class>
     
@@ -1882,6 +1618,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000186">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cytoskeleton structure by inhibiting actin polymerization.</pathgo:IAO_0000115>
         <rdfs:label>actin polymerization inhibition factor</rdfs:label>
     </owl:Class>
     
@@ -1892,6 +1629,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000187">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000193"/>
         <rdfs:label>determinant of sphingomyelinase activity</rdfs:label>
+        <skos:editorialNote>evaluate for removal, concept covered by GO</skos:editorialNote>
     </owl:Class>
     
 
@@ -1899,8 +1637,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by disrupting transport of products into, out of, and within host cells.</pathgo:IAO_0000115>
         <rdfs:label>cellular transport disruption factor</rdfs:label>
+        <skos:editorialNote>elaborate and restructure subclasses</skos:editorialNote>
     </owl:Class>
     
 
@@ -1908,8 +1648,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000189 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000189">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">determinant of enzyme inhibition</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000179"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular metabolism by mediating metabolic enzyme inhibition.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">metabolic enzyme inhibition factor</rdfs:label>
+        <skos:editorialNote>Need examples.  Concept covered by GO.</skos:editorialNote>
     </owl:Class>
     
 
@@ -1919,6 +1661,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000190">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000191"/>
         <rdfs:label>chloride ion channel activator</rdfs:label>
+        <skos:editorialNote>Concept covered by GO, evaluate for removal</skos:editorialNote>
     </owl:Class>
     
 
@@ -1926,8 +1669,10 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000191 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000191">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000040"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000188"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that disrupts cellular transport by modulating ion channel activity.</pathgo:IAO_0000115>
         <rdfs:label>ion channel activity modulator</rdfs:label>
+        <skos:editorialNote>not a consistent subclass; evaluate for better alignment</skos:editorialNote>
     </owl:Class>
     
 
@@ -1935,8 +1680,9 @@
     <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000192 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000192">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000004"/>
-        <rdfs:label>determinant of apoptosis modulation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates pathogenicity by regulating host cell apoptosis. Gene products produced by pathogenic microbes may induce or prevent apoptosis to enable growth inside the host.</pathgo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of apoptosis factor</rdfs:label>
     </owl:Class>
     
 
@@ -1945,7 +1691,21 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000193">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000043"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates membrane damage by cleavage of membrane phospholipids.</pathgo:IAO_0000115>
         <rdfs:label>determinant of phospholipid cleavage</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000194 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000194">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000160"/>
+        <pathgo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A gene product that mediates toxicity by impairing platelet adhesion.</pathgo:IAO_0000115>
+        <rdfs:label>platelet aggregation inhibitor</rdfs:label>
+        <skos:editorialNote rdf:datatype="http://www.w3.org/2001/XMLSchema#string">example: disintegrins
+
+evaluate as appropriate subclass, this is specific case of disrupting cellular adhesion; more appropriate class may be &quot;integrin-dependent adhesion disruption factor&quot;</skos:editorialNote>
     </owl:Class>
     
 
@@ -1954,7 +1714,497 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000195">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000105"/>
+        <pathgo:IAO_0000115>A gene product that promotes proliferation and survival by inducing a proangiogenic response.</pathgo:IAO_0000115>
         <rdfs:label>proangiogenic response factor</rdfs:label>
+        <skos:editorialNote>example VEGF
+
+evaluate proangiogenic response as a contribution to pathogenesis</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000196 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000196">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000210"/>
+        <pathgo:IAO_0000115>A gene product that mediates invasion and dissemination by promoting destruction of extracellular matrix components.</pathgo:IAO_0000115>
+        <rdfs:label>determinant of extracellular matrix destruction</rdfs:label>
+        <skos:editorialNote>gelatinase, mucinase, sialidase, hyaluronidase, etc.</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000197 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000197">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120"/>
+        <pathgo:IAO_0000115>A gene product that mediates adhesion by contributing to the structure of an adhesion appendage.</pathgo:IAO_0000115>
+        <rdfs:label>adhesion appendage component</rdfs:label>
+        <skos:editorialNote>Fimbriae proteins/subunits are examples.  
+
+Intended to capture components that are not directly adhesins, but this class may not be structurally consistent.</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000198 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000198">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000120"/>
+        <pathgo:IAO_0000115>A gene product that mediates adhesion by enabling binding to cell surface receptors or components.</pathgo:IAO_0000115>
+        <rdfs:label>cell surface binding factor</rdfs:label>
+        <skos:editorialNote>sialyl Lewis x binding protein is an example
+
+build out subclasses</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115>A gene product that mediates pathogenicity by manipulating the host cell endomembrane system.</pathgo:IAO_0000115>
+        <rdfs:label>host cell endomembrane system disruption factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000200 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000200">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
+        <rdfs:label>determinant of phagosome escape</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000201 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
+        <rdfs:label>lysosome lysis evasion factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000202 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000202">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
+        <rdfs:label>phagosome acidification disruption factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000203 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000203">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
+        <rdfs:label>phagosome maturation disruption factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000204 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000204">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
+        <rdfs:label>phagolysosome fusion disruption factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000205 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000205">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by enabling evasion of antimicrobial peptides.</pathgo:IAO_0000115>
+        <rdfs:label>antimicrobial peptide evasion factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000206 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000206">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by detoxifying free radicals.</pathgo:IAO_0000115>
+        <rdfs:label>free radical detoxification determinant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000207 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000207">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by suppressing release of inflammatory cytokines.</pathgo:IAO_0000115>
+        <rdfs:label>inflammatory cytokine release suppression factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000208 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000208">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by inhibiting opsonization, the process by which particles are targeted for phagocytosis.</pathgo:IAO_0000115>
+        <rdfs:label>opsonization inhibition factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000209 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000209">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by inhibiting phagocytosis.</pathgo:IAO_0000115>
+        <rdfs:label>phagocytosis inhibition factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000210 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000210">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000073"/>
+        <pathgo:IAO_0000115>A gene product that mediates pathogenicity by facilitating movement into and through host tissues or cells.</pathgo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym>invasin</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>spreading factor</oboInOwl:hasRelatedSynonym>
+        <rdfs:label>invasion and dissemination factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000211 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000038"/>
+        <pathgo:IAO_0000115>A mechanism that mediates adhesion by enabling binding to cell surface receptors or components.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates cell surface binding</rdfs:label>
+        <skos:editorialNote>elaborate subclasses</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000212 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000062"/>
+        <pathgo:IAO_0000115>A mechanism that enables biofilm formation by contributing to quorum sensing.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates quorum sensing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000213 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159"/>
+        <rdfs:label xml:lang="en">platelet aggregation inhibition</rdfs:label>
+        <skos:editorialNote>not an appropriate subclass as this is a specific example, evaluate for class related to inhibition of integrin mediated adhesion</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000214 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000214">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000159"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular adhesion by modulating formation of tight junctions.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">tight junction modification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000215 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000164"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cellular metabolism by mediating inhibition of metabolic enzymes.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates metabolic enzyme inhibition</rdfs:label>
+        <skos:editorialNote>provide examples</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000216 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000216">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cytoskeleton maintenance by mediating actin depolymerization.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates actin depolymerization</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000217 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000217">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cytoskeleton maintenance by promoting actin crosslinking.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates actin crosslinking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000218 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000218">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000090"/>
+        <pathgo:IAO_0000115>A gene product that mediates immune evasion and subversion by blocking immature dendritic immune cells from maturing into antigen-presenting, T cell activating cells.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">dendritic cell maturation inhibitor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000219 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000219">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000105"/>
+        <pathgo:IAO_0000115>A gene product that promotes proliferation and survival by enabling pathogens to survive periods without water, or drought-like conditions.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">desiccation resistance factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000220 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000220">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115>A mechanism that mediates immune evasion and subversion by suppressing release of inflammatory cytokines.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">suppresses inflammatory cytokine release</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000221 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000221">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cytoskeleton maintenance by mediating microtubule stabilization.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates microtubule stabilization</rdfs:label>
+        <skos:editorialNote>https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3625037/</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000222 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000222">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000028"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts cytoskeleton maintenance by mediating microtubule destabilization.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates microtubule destabilization</rdfs:label>
+        <skos:editorialNote>https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3625037/</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000223">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183"/>
+        <pathgo:IAO_0000115>A gene product that disrupts cytoskeleton structure by stabilizing microtubules.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">microtubule stabilization factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000224 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000224">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000183"/>
+        <pathgo:IAO_0000115>A gene product that disrupts cytoskeleton structure by destabilizing microtubules.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">microtubule destabilization factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000225 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000225">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000038"/>
+        <pathgo:IAO_0000115>A mechanism that mediates adhesion by contributing to the formation of an adhesion appendage.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">contributes to adhesion appendage formation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000226 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000226">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000235"/>
+        <pathgo:IAO_0000115>A mechanism that mediates invasion and dissemination by disrupting extracellular matrix components.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">disrupts extracellular matrix</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000227 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000227">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000043"/>
+        <pathgo:IAO_0000115>A gene product that mediates membrane damage by degradation of polysaccharides.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">determinant of polysaccharide degradation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000228 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000228">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000165"/>
+        <pathgo:IAO_0000115>A mechanism that disrupts host cellular signaling by modulating levels of second messenger molecules.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">disrupts second messenger levels</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000229 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000229">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000212"/>
+        <pathgo:IAO_0000115>A mechanism that contributes to quorum sensing by promoting production of autoinducer molecules.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates quorum sensing autoinducer production</rdfs:label>
+        <skos:editorialNote>autoinducer synthase</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000230 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115>A mechanism that mediates immune evasion and subversion by detoxifying free radicals.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">mediates free radical detoxification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000231 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000231">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115>A mechanism that mediates immune evasion and subversion by inhibiting opsonization, the process by which particles are targeted for phagocytosis.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">inhibits opsonization</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000232 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115>A mechanism that mediates immune evasion and subversion by inhibiting phagocytosis.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">inhibits phagocytosis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000233 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000233">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000085"/>
+        <pathgo:IAO_0000115>A mechanism that mediates immune evasion and subversion by disrupting toll-like receptor signaling.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">disrupts toll-like receptor signaling</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000234">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000211"/>
+        <rdfs:comment>A mechanism that mediates cell surface binding through integrins.</rdfs:comment>
+        <rdfs:label xml:lang="en">mediates integrin binding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000235 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000235">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <rdfs:comment>A mechanism that mediates pathogenicity by facilitating movement into and through host tissues or cells.</rdfs:comment>
+        <rdfs:label xml:lang="en">mediates invasion and dissemination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000114"/>
+        <pathgo:IAO_0000115>A mechanism that mediates pathogenicity by manipulating the host cell endomembrane system.</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">disrupts host cell endomembrane system</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000237 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <rdfs:label xml:lang="en">mediates phagosome escape</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000238 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000238">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <rdfs:label xml:lang="en">mediates evasion of lysosome lysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000239 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000239">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <rdfs:label xml:lang="en">disrupts phagolysosome fusion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000240 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000240">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <rdfs:label xml:lang="en">disrupts phagosome acidification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000241 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
+        <rdfs:label xml:lang="en">disrupts phagosome maturation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000242">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000099"/>
+        <pathgo:IAO_0000115>A mechanism that mediates extracellular matrix binding by adhering specifically to vitronectin</pathgo:IAO_0000115>
+        <rdfs:label xml:lang="en">host vitronectin-binding</rdfs:label>
+        <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000244">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000006"/>
+        <rdfs:label xml:lang="en">mediates elongation factor 1 inactivation</rdfs:label>
+        <skos:definition>A mechanism that mediates protein synthesis inhibition by inactivation of elongation factor 1.</skos:definition>
+        <skos:editorialNote>examples Legionella glycosylating toxins and SidI, SARS-CoV N protein</skos:editorialNote>
     </owl:Class>
 </rdf:RDF>
 

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -38,10 +38,11 @@ prepare_release: all
 # after that we annotate the ontology with the release versionInfo
 $(ONT).owl: $(SRC)
 	$(ROBOT) reason -i $< -r ELK relax reduce -r ELK annotate -V $(BASE)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
-	cp $^ $(RELEASEDIR)
+	cp $(ONT).owl $(RELEASEDIR)
 $(ONT).obo: $(ONT).owl
+	echo "Making $(ONT).obo file now..."
 	$(ROBOT) convert -i $< -f obo -o $(ONT).obo.tmp && mv $(ONT).obo.tmp $@
-	cp $^ $(RELEASEDIR)
+	cp $(ONT).obo $(RELEASEDIR)
 
 # ----------------------------------------
 # Import modules


### PR DESCRIPTION
This change causes the .owl and .obo files to be copied from the src/ontology folder to the main folder when building the ontology.  Not related to content of the ontology.