### PR TITLE
Update pathgo-edit.owl

### DIFF
--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -1735,6 +1735,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000200">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>determinant of escape from host phagosome</rdfs:label>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by mediating pathogen escape from host phagosome.</skos:definition>
     </owl:Class>
     
 
@@ -1744,6 +1745,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>lysosome lysis evasion factor</rdfs:label>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by mediating lysosome lysis evasion.</skos:definition>
     </owl:Class>
     
 
@@ -1753,6 +1755,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000202">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>phagosome acidification disruption factor</rdfs:label>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting phagosome acidification.</skos:definition>
     </owl:Class>
     
 
@@ -1762,6 +1765,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>host cell phagosome maturation disruption factor</rdfs:label>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting host cell phagosome maturation.</skos:definition>
     </owl:Class>
     
 
@@ -1771,6 +1775,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>phagolysosome fusion disruption factor</rdfs:label>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting phagosome fusion.</skos:definition>
     </owl:Class>
     
 
@@ -2210,8 +2215,8 @@ Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:edi
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000248">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
-        <pathgo:IAO_0000115>A factor that inhibits one or more of the typical fusions between vesicles and other compartments that occur in normal host endosomal dynamics.</pathgo:IAO_0000115>
         <rdfs:label xml:lang="en">endosomal vesicle fusion inhibition factor</rdfs:label>
+        <skos:definition>A gene product modulates host cell endomembrane dynamics by inhibiting one or more of the typical fusions between vesicles and other compartments that occur in normal host endosomal dynamics.</skos:definition>
         <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
     </owl:Class>
     
@@ -3025,7 +3030,7 @@ Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:edi
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000322">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
-        <pathgo:IAO_0000115>A gene product that disrupts the host endomembrane system by modulating the trafficking of vesicles to other cellular compartments that occur as part of normal host function.</pathgo:IAO_0000115>
+        <pathgo:IAO_0000115>A gene product that modulates host cell endomembrane dynamics by modulating the trafficking of vesicles to other cellular compartments that occur as part of normal host function.</pathgo:IAO_0000115>
         <rdfs:label xml:lang="en">endosomal vesicle trafficking modulation factor</rdfs:label>
         <skos:editorialNote>Term suggested by Gene Godbold (https://orcid.org/0000-0002-5702-4690)</skos:editorialNote>
     </owl:Class>

--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -2125,6 +2125,7 @@ Intended to capture components that are not directly adhesins, but this class ma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000237">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">mediates escape from host phagosome</rdfs:label>
+        <skos:definition>A mechanism that modulates host cell endomembrane dynamics by mediating escape from host phagosome.</skos:definition>
     </owl:Class>
     
 
@@ -2134,6 +2135,7 @@ Intended to capture components that are not directly adhesins, but this class ma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000238">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">mediates evasion of lysosome lysis</rdfs:label>
+        <skos:definition>A mechanism that modulates host cell endomembrane dynamics by mediating evasion of lysosome lysis.</skos:definition>
     </owl:Class>
     
 
@@ -2143,6 +2145,7 @@ Intended to capture components that are not directly adhesins, but this class ma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">disrupts phagolysosome fusion</rdfs:label>
+        <skos:definition>A mechanism that modulates host cell endomembrane dynamics by disrupting phagolysosome fusion.</skos:definition>
     </owl:Class>
     
 
@@ -2152,6 +2155,7 @@ Intended to capture components that are not directly adhesins, but this class ma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">disrupts phagosome acidification</rdfs:label>
+        <skos:definition>A mechanism that modulates host cell endomembrane dynamics by disrupting phagosome acidification.</skos:definition>
     </owl:Class>
     
 
@@ -2161,6 +2165,7 @@ Intended to capture components that are not directly adhesins, but this class ma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000241">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000236"/>
         <rdfs:label xml:lang="en">disrupts phagosome maturation in host cell</rdfs:label>
+        <skos:definition>A mechanism that modulates host cell endomembrane dynamics by disrupting phagosome maturation in the host cell.</skos:definition>
     </owl:Class>
     
 

--- a/src/ontology/pathgo-edit.owl
+++ b/src/ontology/pathgo-edit.owl
@@ -1755,7 +1755,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000202">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>phagosome acidification disruption factor</rdfs:label>
-        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting phagosome acidification.</skos:definition>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by disrupting phagosome acidification.</skos:definition>
     </owl:Class>
     
 
@@ -1765,7 +1765,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>host cell phagosome maturation disruption factor</rdfs:label>
-        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting host cell phagosome maturation.</skos:definition>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by disrupting host cell phagosome maturation.</skos:definition>
     </owl:Class>
     
 
@@ -1775,7 +1775,7 @@ build out subclasses</skos:editorialNote>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/pathgo/PATHGO_0000199"/>
         <rdfs:label>phagolysosome fusion disruption factor</rdfs:label>
-        <skos:definition>A gene product that modulates host cell endomembrane dynamics by dirupting phagosome fusion.</skos:definition>
+        <skos:definition>A gene product that modulates host cell endomembrane dynamics by disrupting phagolysosome fusion.</skos:definition>
     </owl:Class>
     
 


### PR DESCRIPTION
Added definitions for PATHGO 200-204 and edited definitions for 248 and 322 (also in that host cell endomembrane dynamics modulation factor grouping) to make them fit the standard definition format since I noticed they did not. Addresses part of issue #142
Added definitions to PATHGO 237-241. Addressed second half of issue #142